### PR TITLE
Clean up website gen content before regenerating.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ trebvet:
 
 .PHONY: gensite
 gensite:
+	rm -rf ./website/gen/*
 	$Qdocker build \
 		-f Dockerfile-webgen \
 		-t ctlstore-webgen \


### PR DESCRIPTION
This will prevent old generated JS files from lingering about.

cc @bryanmikaelian 