### PR TITLE
Do not instrument shovel seq skips as normal errors.

### DIFF
--- a/pkg/reflector/reflector.go
+++ b/pkg/reflector/reflector.go
@@ -261,7 +261,14 @@ func (r *Reflector) Start(ctx context.Context) error {
 		case events.IsTermination(errors.Cause(err)): // this is normal
 			events.Log("Reflector received termination signal")
 		case err != nil:
-			errs.Incr("reflector.shovel_error")
+			switch {
+			case errors.Is("SkippedSequence", err):
+				// this is instrumented elsewhere and is not an error that we need
+				// to handle normally, so we will skip instrumenting this as a
+				// shovel_error for now.
+			default:
+				errs.Incr("reflector.shovel_error")
+			}
 			events.Log("Error encountered during shoveling: %{error}+v", err)
 		}
 		select {

--- a/pkg/reflector/shovel.go
+++ b/pkg/reflector/shovel.go
@@ -2,13 +2,13 @@ package reflector
 
 import (
 	"context"
-	"errors"
 	"io"
 	"time"
 
 	"github.com/segmentio/ctlstore/pkg/errs"
 	"github.com/segmentio/ctlstore/pkg/ldbwriter"
 	"github.com/segmentio/ctlstore/pkg/schema"
+	"github.com/segmentio/errors-go"
 	"github.com/segmentio/events"
 	"github.com/segmentio/stats"
 )
@@ -100,7 +100,9 @@ func (s *shovel) Start(ctx context.Context) error {
 				if s.abortOnSeqSkip {
 					// Mitigation for a bug that we haven't found yet
 					stats.Incr("shovel.skipped_sequence_abort")
-					return errors.New("shovel skipped sequence")
+					err = errors.New("shovel skipped sequence")
+					err = errors.WithTypes(err, "SkippedSequence")
+					return err
 				}
 			}
 		}


### PR DESCRIPTION
When the reflector shovel fails, it's normally instrumented as
an error with the tag `reflector.shovel_error`. We still will
be monitoring the ledger skips, but will use different
thresholds than other errors.  To that end we will not
instrument the sequence skips as typical errors in the code.