### PR TITLE
Do not enforce sidecar max rows by default.

### DIFF
--- a/pkg/cmd/ctlstore/main.go
+++ b/pkg/cmd/ctlstore/main.go
@@ -407,7 +407,6 @@ func executive(ctx context.Context, args []string) {
 func sidecar(ctx context.Context, args []string) {
 	config := sidecarConfig{
 		BindAddr:  "0.0.0.0:1331",
-		MaxRows:   1000,
 		Dogstatsd: defaultDogstatsdConfig(),
 	}
 	loadConfig(&config, "sidecar", args)


### PR DESCRIPTION
This limit effectively only lives in the sidecar, thus providing
a different behavior when using the sidecar versus the client
itself.

I'm leaving the ability for folks to set the max-rows limit if
they wish, but by default it will be off for now.