### PR TITLE
Instrument ledger latency independently

### DIFF
--- a/pkg/cmd/ctlstore/main.go
+++ b/pkg/cmd/ctlstore/main.go
@@ -91,7 +91,8 @@ type supervisorCliConfig struct {
 // instance attribute tagging. Ledger latency health will be
 // reflected in container instance attributes.
 type ledgerHealthConfig struct {
-	Disable                 bool          `conf:"disable" help:"disable ledger latency health attributing"`
+	Disable                 bool          `conf:"disable" help:"disable ledger latency health attributing (DEPRECATED: use disable-ecs-behavior instead)"`
+	DisableECSBehavior      bool          `conf:"disable-ecs-behavior" help:"disable ledger latency health attributing"`
 	MaxHealthyLatency       time.Duration `conf:"max-healty-latency" help:"Max latency considered healthy"`
 	AttributeName           string        `conf:"attribute-name" help:"The name of the attribute"`
 	HealthyAttributeValue   string        `conf:"healthy-attribute-value" help:"The value of the attribute if healthy"`
@@ -491,6 +492,9 @@ func newSidecar(config sidecarConfig) (*sidecarpkg.Sidecar, error) {
 }
 
 func newReflector(cliCfg reflectorCliConfig, isSupervisor bool) (*reflectorpkg.Reflector, error) {
+	if cliCfg.LedgerHealth.Disable {
+		events.Log("DEPRECATION NOTICE: use --disable-ecs-behavior instead of --disable to control this ledger monitor behavior")
+	}
 	return reflectorpkg.ReflectorFromConfig(reflectorpkg.ReflectorConfig{
 		LDBPath:       cliCfg.LDBPath,
 		ChangelogPath: cliCfg.ChangelogPath,
@@ -498,7 +502,7 @@ func newReflector(cliCfg reflectorCliConfig, isSupervisor bool) (*reflectorpkg.R
 		BootstrapURL:  cliCfg.BootstrapURL,
 		IsSupervisor:  isSupervisor,
 		LedgerHealth: ledger.HealthConfig{
-			Disable:                 cliCfg.LedgerHealth.Disable,
+			DisableECSBehavior:      cliCfg.LedgerHealth.Disable || cliCfg.LedgerHealth.DisableECSBehavior,
 			MaxHealthyLatency:       cliCfg.LedgerHealth.MaxHealthyLatency,
 			AttributeName:           cliCfg.LedgerHealth.AttributeName,
 			HealthyAttributeValue:   cliCfg.LedgerHealth.HealthyAttributeValue,

--- a/pkg/reflector/dml_source.go
+++ b/pkg/reflector/dml_source.go
@@ -85,13 +85,10 @@ func (source *sqlDmlSource) Next(ctx context.Context) (statement schema.DMLState
 				stats.Incr("sql_dml_source.skipped_sequence")
 			}
 
-			// instrument how latent this record is compared to wall time
 			timestamp, err := time.Parse(dmlLedgerTimestampFormat, row.leaderTs)
 			if err != nil {
 				return statement, errors.Wrapf(err, "could not parse time '%s'", row.leaderTs)
 			}
-			latency := time.Now().Sub(timestamp)
-			stats.Observe("reflector-ledger-latency", latency)
 
 			dmlst := schema.DMLStatement{
 				Sequence:  schema.DMLSequence(row.seq),

--- a/pkg/reflector/reflector_test.go
+++ b/pkg/reflector/reflector_test.go
@@ -151,6 +151,7 @@ func TestReflector(t *testing.T) {
 		},
 		LedgerHealth: ledger.HealthConfig{
 			DisableECSBehavior: true,
+			PollInterval:       10 * time.Second,
 		},
 	}
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/reflector/reflector_test.go
+++ b/pkg/reflector/reflector_test.go
@@ -62,7 +62,7 @@ func TestShovelSequenceReset(t *testing.T) {
 			PollTimeout:    10 * time.Millisecond,
 		},
 		LedgerHealth: ledger.HealthConfig{
-			Disable: true,
+			DisableECSBehavior: true,
 		},
 	}
 	reflector, err := ReflectorFromConfig(cfg)
@@ -150,7 +150,7 @@ func TestReflector(t *testing.T) {
 			PollTimeout:    10 * time.Millisecond,
 		},
 		LedgerHealth: ledger.HealthConfig{
-			Disable: true,
+			DisableECSBehavior: true,
 		},
 	}
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Currently the ledger latency is monitored as part of the usual
business of writing to the ledger. This means, though, that if
there is a partition to the ctldb, and the reflector is not
able to fetch ledger entries to write, that the ledger latency
will not be instrumented until the partition is resolved.

This change moves the instrumentation behavior to the existing
ledger Monitor which used to only set healthy/unhealthy ECS
attributes.  In this way, it will independently tick and measure
the latency regardless of whether or not the reflector is
applying updates from the ledger.