### PR TITLE
Sidecar improvements

### DIFF
--- a/pkg/cmd/ctlstore/main.go
+++ b/pkg/cmd/ctlstore/main.go
@@ -38,10 +38,11 @@ type dogstatsdConfig struct {
 }
 
 type sidecarConfig struct {
-	BindAddr  string          `conf:"bind-addr" help:"The address and port to bind on"`
-	LDBPath   string          `conf:"ldb-path" help:"The location of the LDB"`
-	MaxRows   int             `conf:"max-rows" help:"Maximum number of rows that can be returned in one response"`
-	Dogstatsd dogstatsdConfig `conf:"dogstatsd" help:"dogstatsd Configuration"`
+	BindAddr    string          `conf:"bind-addr" help:"The address and port to bind on"`
+	LDBPath     string          `conf:"ldb-path" help:"The location of the LDB"`
+	MaxRows     int             `conf:"max-rows" help:"Maximum number of rows that can be returned in one response"`
+	Application string          `conf:"application" help:"The name of the application that will be using the sidecar"`
+	Dogstatsd   dogstatsdConfig `conf:"dogstatsd" help:"dogstatsd Configuration"`
 }
 
 type reflectorCliConfig struct {

--- a/pkg/sidecar/sidecar.go
+++ b/pkg/sidecar/sidecar.go
@@ -176,6 +176,7 @@ func (s *Sidecar) getRowsByKeyPrefix(w http.ResponseWriter, r *http.Request) err
 	if err != nil {
 		return err
 	}
+	stats.Observe("get-rows-by-key-prefix-num-rows", len(res), stats.T("family", family), stats.T("table", table))
 	err = json.NewEncoder(w).Encode(res)
 	return err
 }

--- a/pkg/sidecar/sidecar_test.go
+++ b/pkg/sidecar/sidecar_test.go
@@ -111,6 +111,7 @@ func TestFetchCtlstoreData(t *testing.T) {
 		family      string
 		table       string
 		useMulti    bool
+		maxRows     int
 		rr          ReadRequest
 		status      int
 		respHeaders map[string]string
@@ -190,6 +191,15 @@ func TestFetchCtlstoreData(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "too many rows returned",
+			family:   "test_family",
+			table:    "test_table",
+			useMulti: true,
+			maxRows:  1,
+			rr:       ReadRequest{[]Key{}},
+			status:   http.StatusRequestedRangeNotSatisfiable,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tu, teardown := ctlstore.NewLDBTestUtil(t)
@@ -221,7 +231,7 @@ func TestFetchCtlstoreData(t *testing.T) {
 			})
 			sc, err := New(Config{
 				Reader:  ctlstore.NewLDBReaderFromDB(tu.DB),
-				MaxRows: 0,
+				MaxRows: test.maxRows,
 			})
 			require.NoError(t, err)
 			keys, err := json.Marshal(test.rr)


### PR DESCRIPTION
This changeset brings a number of improvements to the HTTP sidecar:

* Use the https://github.com/segmentio/stats/tree/master/httpstats package to automatically instrument the sidecar http.Handler
* If a limit on the number of rows that `get-rows-by-key-prefix` may return is set, and then exceeded, an HTTP/416 will be returned
* The number of rows fetched by `get-row-by-key-prefix` are now instrumented with a histogram