### PR TITLE
Enable request path tags in httpstats metrics.

### DIFF
--- a/pkg/sidecar/sidecar.go
+++ b/pkg/sidecar/sidecar.go
@@ -12,6 +12,7 @@ import (
 	"github.com/segmentio/ctlstore"
 	"github.com/segmentio/errors-go"
 	"github.com/segmentio/stats"
+	"github.com/segmentio/stats/datadog"
 	"github.com/segmentio/stats/httpstats"
 )
 
@@ -87,6 +88,7 @@ func New(config Config) (*Sidecar, error) {
 	mux.HandleFunc("/ping", handleErr(sidecar.ping)).Methods("GET")
 
 	application := orUnknown(config.Application)
+	datadog.DefaultFilters = []string{}
 	stats.DefaultEngine.Tags = append(stats.DefaultEngine.Tags, stats.T("application", application))
 	stats.DefaultEngine.Tags = stats.SortTags(stats.DefaultEngine.Tags) // tags must be sorted
 


### PR DESCRIPTION
By default these are disabled b/c of tag value cardinality
concerns, but for the sidecar, the number of <family,table> pairs
are somewhat bounded, so it makes sense to open 'em up.