### PR TITLE
Set default filters in the DD client config.

### DIFF
--- a/pkg/sidecar/sidecar.go
+++ b/pkg/sidecar/sidecar.go
@@ -12,7 +12,6 @@ import (
 	"github.com/segmentio/ctlstore"
 	"github.com/segmentio/errors-go"
 	"github.com/segmentio/stats"
-	"github.com/segmentio/stats/datadog"
 	"github.com/segmentio/stats/httpstats"
 )
 
@@ -88,7 +87,6 @@ func New(config Config) (*Sidecar, error) {
 	mux.HandleFunc("/ping", handleErr(sidecar.ping)).Methods("GET")
 
 	application := orUnknown(config.Application)
-	datadog.DefaultFilters = []string{}
 	stats.DefaultEngine.Tags = append(stats.DefaultEngine.Tags, stats.T("application", application))
 	stats.DefaultEngine.Tags = stats.SortTags(stats.DefaultEngine.Tags) // tags must be sorted
 


### PR DESCRIPTION
Before we were just setting the package level defaults, which,
at that time, had already been read and copied into the DD
Client.

Also, some light refactoring of the configureDogstatsd func in
order to contain the parameter explosion.