### PR TITLE
Check LDB exists before returning an LDBReader.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,7 @@
 version: '2.2'
-
 services:
     mysql:
         image: mysql:5.6
-        volumes:
-            - dbdata:/var/lib/mysql
         restart:
             always
         ports:
@@ -15,6 +12,3 @@ services:
             MYSQL_USER: ctldb
             MYSQL_PASSWORD: ctldbpw
         mem_limit: 536870912
-
-volumes:
-    dbdata:

--- a/ldb.go
+++ b/ldb.go
@@ -1,6 +1,7 @@
 package ctlstore
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -34,6 +35,14 @@ func init() {
 // ReaderForPath opens an LDB at the provided path and returns an LDBReader
 // instance pointed at that LDB.
 func ReaderForPath(path string) (*LDBReader, error) {
+	_, err := os.Stat(path)
+	switch {
+	case os.IsNotExist(err):
+		return nil, fmt.Errorf("no LDB found at %s", path)
+	case err != nil:
+		return nil, err
+	}
+
 	mode := "ro"
 	if !globalLDBReadOnly {
 		mode = "rwc"


### PR DESCRIPTION
The `Reader` and `ReaderForPath` methods return both an `LDBReader` and an `error`.  The error return will now be non-nil if the path specified does not actually exist on the filesystem.  

