### PR TITLE
Test against latest segementio/go-sqlite3 driver.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/segmentio/errors-go v1.0.0
 	github.com/segmentio/events v0.0.0-20180910023553-a3cc374e8b73
 	github.com/segmentio/go-snakecase v1.0.0 // indirect
-	github.com/segmentio/go-sqlite3 v1.9.2-0.20190912151732-d6c2d79f4a5d
+	github.com/segmentio/go-sqlite3 v1.11.1
 	github.com/segmentio/objconv v1.0.1 // indirect
 	github.com/segmentio/stats v0.0.0-20180910023949-03436e32c942
 	github.com/segmentio/taskstats v0.0.0-20180810220338-a98a7e99006d // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/segmentio/go-sqlite3 v1.9.1 h1:zgy7sgxQQLwb9Xj0JYADMa/z9ii9C2jzFIBqx/
 github.com/segmentio/go-sqlite3 v1.9.1/go.mod h1:z/iftdsESjnobPNbO6U17aiq8MTcYsA6SxzhLHCJVSE=
 github.com/segmentio/go-sqlite3 v1.9.2-0.20190912151732-d6c2d79f4a5d h1:VowCQh7nVu05vdIZ1HX+QtHfXQJ9vySd++7aJb3b3ro=
 github.com/segmentio/go-sqlite3 v1.9.2-0.20190912151732-d6c2d79f4a5d/go.mod h1:z/iftdsESjnobPNbO6U17aiq8MTcYsA6SxzhLHCJVSE=
+github.com/segmentio/go-sqlite3 v1.11.1 h1:wsEA3eAtAYh3L/BkQ3armFwJ6hg4fwJB6o/pumhLQ5E=
+github.com/segmentio/go-sqlite3 v1.11.1/go.mod h1:z/iftdsESjnobPNbO6U17aiq8MTcYsA6SxzhLHCJVSE=
 github.com/segmentio/objconv v0.0.0-20180216231955-8998c9cea5fb/go.mod h1:l6IU9rGW/wpM+MUyfJLDCoJ+XXAv6wbpkqej46ESQ6g=
 github.com/segmentio/objconv v1.0.0/go.mod h1:l6IU9rGW/wpM+MUyfJLDCoJ+XXAv6wbpkqej46ESQ6g=
 github.com/segmentio/objconv v1.0.1 h1:QjfLzwriJj40JibCV3MGSEiAoXixbp4ybhwfTB8RXOM=


### PR DESCRIPTION
This driver change brings our fork to the latest 1.x tag which
also has a nice benefit of fixing a CGO memory leak to boot.