### PR TITLE
[F8N-865] Enable globalstats by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /vendor
 /bin
 .coverprofile
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ install:
 
 .PHONY: build
 build: deps
-	$Qgo build -ldflags="-X github.com/segmentio/ctlstore.Version=${VERSION}" -o ./bin/ctlstore ./pkg/cmd/ctlstore
+	$Qgo build -ldflags="-X github.com/segmentio/ctlstore.Version=${VERSION} -X github.com/segmentio/ctlstore/pkg/globalstats.version=${VERSION}" -o ./bin/ctlstore ./pkg/cmd/ctlstore
 
 .PHONY: docker
 docker:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ Q=
 
 GOTESTFLAGS = -race -count 1
 
+export GO111MODULE?=on
+
 .PHONY: deps
 deps:
 	$Qgo get -d ./...

--- a/initialize.go
+++ b/initialize.go
@@ -7,13 +7,6 @@ import (
 	"github.com/segmentio/stats"
 )
 
-// By default, initialize ctlstore with some sane defaults.
-func init() {
-	// Use the default global stats application name.
-	appName := ""
-	Initialize(context.Background(), appName, stats.DefaultEngine.Handler)
-}
-
 // Initialize setup up global state for thing including global
 // metrics globalstats data and possibly more as time goes on.
 func Initialize(ctx context.Context, appName string, statsHandler stats.Handler) {

--- a/initialize.go
+++ b/initialize.go
@@ -7,6 +7,13 @@ import (
 	"github.com/segmentio/stats"
 )
 
+// By default, initialize ctlstore with some sane defaults.
+func init() {
+	// Use the default global stats application name.
+	appName := ""
+	Initialize(context.Background(), appName, stats.DefaultEngine.Handler)
+}
+
 // Initialize setup up global state for thing including global
 // metrics globalstats data and possibly more as time goes on.
 func Initialize(ctx context.Context, appName string, statsHandler stats.Handler) {

--- a/pkg/globalstats/stats.go
+++ b/pkg/globalstats/stats.go
@@ -98,7 +98,8 @@ func lazyInitializeEngine() {
 	}
 	if config.SamplePct == 0 {
 		// By default, only sample 10% of the observations.
-		config.SamplePct = 0.10
+		// TODO: reset to 10% vvvv
+		config.SamplePct = 1
 	}
 	if config.FlushEvery == 0 {
 		config.FlushEvery = 10 * time.Second

--- a/pkg/globalstats/stats.go
+++ b/pkg/globalstats/stats.go
@@ -137,14 +137,11 @@ func lazyInitializeEngine() {
 	}
 	engine = stats.NewEngine(statsPrefix, config.StatsHandler, tags...)
 
-	defer flusher(globalctx, flusherStop, config.FlushEvery)
+	defer flusher(globalctx, flusherStop, config.FlushEvery, engine)
 }
 
-func flusher(ctx context.Context, stop <-chan struct{}, flushEvery time.Duration) {
-	defer func() {
-		engine.Flush()
-	}()
-
+func flusher(ctx context.Context, stop <-chan struct{}, flushEvery time.Duration, engine *stats.Engine) {
+	defer engine.Flush()
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/globalstats/stats.go
+++ b/pkg/globalstats/stats.go
@@ -106,8 +106,7 @@ func lazyInitializeEngine() (*stats.Engine, bool) {
 	}
 	if config.SamplePct == 0 {
 		// By default, only sample 10% of the observations.
-		// TODO: reset to 10% vvvv
-		config.SamplePct = 1
+		config.SamplePct = 0.10
 	}
 	if config.FlushEvery == 0 {
 		config.FlushEvery = 10 * time.Second

--- a/pkg/globalstats/stats.go
+++ b/pkg/globalstats/stats.go
@@ -149,7 +149,7 @@ func lazyInitializeEngine() (*stats.Engine, bool) {
 	}
 	engine = stats.NewEngine(statsPrefix, config.StatsHandler, tags...)
 
-	defer flusher(globalctx, flusherStop, config.FlushEvery, engine)
+	go flusher(globalctx, flusherStop, config.FlushEvery, engine)
 
 	return engine, true
 }

--- a/pkg/globalstats/stats.go
+++ b/pkg/globalstats/stats.go
@@ -104,11 +104,11 @@ func lazyInitializeEngine() {
 	if config.FlushEvery == 0 {
 		config.FlushEvery = 10 * time.Second
 	}
+	if config.StatsHandler == nil {
+		config.StatsHandler = stats.DefaultEngine.Handler
+	}
 
 	err := func() error {
-		if config.StatsHandler == nil {
-			return errors.New("no datadog client supplied")
-		}
 		if config.SamplePct > 1 || config.SamplePct < 0 {
 			return errors.New("sample percentage must be in the range of (0, 1]")
 		}

--- a/pkg/globalstats/stats.go
+++ b/pkg/globalstats/stats.go
@@ -18,6 +18,11 @@ const (
 	statsPrefix = "ctlstore.global"
 )
 
+// version will be set by CI using ld_flags to the git SHA on which the binary was built
+var (
+	version = "unknown"
+)
+
 type (
 	Config struct {
 		CtlstoreVersion string
@@ -107,6 +112,9 @@ func lazyInitializeEngine() {
 	if config.StatsHandler == nil {
 		config.StatsHandler = stats.DefaultEngine.Handler
 	}
+	if config.CtlstoreVersion == "" {
+		config.CtlstoreVersion = version
+	}
 
 	err := func() error {
 		if config.SamplePct > 1 || config.SamplePct < 0 {
@@ -114,9 +122,6 @@ func lazyInitializeEngine() {
 		}
 		if config.FlushEvery < 0 {
 			return errors.New("flush rate must be a positive duration")
-		}
-		if config.CtlstoreVersion == "" {
-			return errors.New("must supply the ctlstore version")
 		}
 
 		return nil


### PR DESCRIPTION
This PR enables `globalstats` by default. Previously, `globalstats` was opt-in, but this led to unreliable usage/performance stats. Considering we perform batching on these stats, the overhead of enabling `globalstats` is low, so we want to move towards an opt-out strategy instead.

This PR is based on @collinvandyck's proposal here, but takes a lazy initialization approach to avoid launching a goroutine from `init` / simplify the logic for getting the default stats handler: https://github.com/segmentio/ctlstore/compare/init-thoughts?expand=1