### PR TITLE
[F8N-755] Halt snapshots if supervisor's ledger is out-of-date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /vendor
 /bin
 .coverprofile
+.vscode

--- a/ldb_reader.go
+++ b/ldb_reader.go
@@ -50,6 +50,23 @@ func (reader *LDBReader) GetLastSequence(ctx context.Context) (schema.DMLSequenc
 	return ldb.FetchSeqFromLdb(ctx, reader.Db)
 }
 
+type Latencier interface {
+	GetLedgerLatency(ctx context.Context) (time.Duration, error)
+}
+
+type MockLatencier struct {
+	Latency time.Duration
+	Err     error
+}
+
+var _ Latencier = (*MockLatencier)(nil)
+
+func (l *MockLatencier) GetLedgerLatency(ctx context.Context) (time.Duration, error) {
+	return l.Latency, l.Err
+}
+
+var _ Latencier = (*LDBReader)(nil)
+
 // GetLedgerLatency returns the difference between the current time and the timestamp
 // from the last DML ledger update processed by the reflector. ErrNoLedgerUpdates will
 // be returned if no DML statements have been processed.

--- a/ldb_reader.go
+++ b/ldb_reader.go
@@ -50,23 +50,6 @@ func (reader *LDBReader) GetLastSequence(ctx context.Context) (schema.DMLSequenc
 	return ldb.FetchSeqFromLdb(ctx, reader.Db)
 }
 
-type Latencier interface {
-	GetLedgerLatency(ctx context.Context) (time.Duration, error)
-}
-
-type MockLatencier struct {
-	Latency time.Duration
-	Err     error
-}
-
-var _ Latencier = (*MockLatencier)(nil)
-
-func (l *MockLatencier) GetLedgerLatency(ctx context.Context) (time.Duration, error) {
-	return l.Latency, l.Err
-}
-
-var _ Latencier = (*LDBReader)(nil)
-
 // GetLedgerLatency returns the difference between the current time and the timestamp
 // from the last DML ledger update processed by the reflector. ErrNoLedgerUpdates will
 // be returned if no DML statements have been processed.

--- a/pkg/cmd/ctlstore/main.go
+++ b/pkg/cmd/ctlstore/main.go
@@ -79,14 +79,14 @@ type executiveCliConfig struct {
 // running its own reflector.  The LDBPath will come from the composed
 // reflector config instead of being a top level element in this struct.
 type supervisorCliConfig struct {
-	SnapshotInterval     time.Duration      `conf:"snapshot-interval" help:"Wait time between snapshots" validate:"nonzero"`
-	SnapshotURL          string             `conf:"snapshot-url" help:"URL for snapshot upload (i.e. s3://bucket/key)" validate:"nonzero"`
-	Debug                bool               `conf:"debug" help:"Turns on debug logging"`
-	LedgerLatencyConfig  ledgerHealthConfig `conf:"ledger-latency-health" help:"Configures ledger latency health behavior"`
-	ReflectorConfig      reflectorCliConfig `conf:"reflector" help:"reflector configuration"`
-	Shadow               bool               `conf:"shadow" help:"set this to true to emit shadow=true metric tags"`
-	Dogstatsd            dogstatsdConfig    `conf:"dogstatsd" help:"dogstatsd Configuration"`
-	MinimumLedgerLatency time.Duration      `conf:"minimum-ledger-latency" help:"Minimum ledger latency, at which the supervisor halts snapshots and waits for the ledger to catch up."`
+	SnapshotInterval    time.Duration      `conf:"snapshot-interval" help:"Wait time between snapshots" validate:"nonzero"`
+	SnapshotURL         string             `conf:"snapshot-url" help:"URL for snapshot upload (i.e. s3://bucket/key)" validate:"nonzero"`
+	Debug               bool               `conf:"debug" help:"Turns on debug logging"`
+	LedgerLatencyConfig ledgerHealthConfig `conf:"ledger-latency-health" help:"Configures ledger latency health behavior"`
+	ReflectorConfig     reflectorCliConfig `conf:"reflector" help:"reflector configuration"`
+	Shadow              bool               `conf:"shadow" help:"set this to true to emit shadow=true metric tags"`
+	Dogstatsd           dogstatsdConfig    `conf:"dogstatsd" help:"dogstatsd Configuration"`
+	MaxLedgerLatency    time.Duration      `conf:"minimum-ledger-latency" help:"Minimum ledger latency, at which the supervisor halts snapshots and waits for the ledger to catch up."`
 }
 
 // ledgerHealthConfig configures the behavior of the container
@@ -263,10 +263,10 @@ func supervisor(ctx context.Context, args []string) {
 	err := func() error {
 		reflectorConfig := defaultReflectorCLIConfig(true)
 		cliCfg := supervisorCliConfig{
-			SnapshotInterval:     5 * time.Minute,
-			Dogstatsd:            defaultDogstatsdConfig(),
-			ReflectorConfig:      reflectorConfig,
-			MinimumLedgerLatency: time.Minute,
+			SnapshotInterval: 5 * time.Minute,
+			Dogstatsd:        defaultDogstatsdConfig(),
+			ReflectorConfig:  reflectorConfig,
+			MaxLedgerLatency: time.Minute,
 		}
 		loadConfig(&cliCfg, "supervisor", args)
 		if cliCfg.Debug {
@@ -293,11 +293,11 @@ func supervisor(ctx context.Context, args []string) {
 		}
 
 		supervisor, err := supervisorpkg.SupervisorFromConfig(supervisorpkg.SupervisorConfig{
-			SnapshotInterval:     cliCfg.SnapshotInterval,
-			SnapshotURL:          cliCfg.SnapshotURL,
-			LDBPath:              cliCfg.ReflectorConfig.LDBPath, // use the reflector config's ldb path here
-			Reflector:            reflector,                      // compose the reflector, since it will start with the supervisor
-			MinimumLedgerLatency: cliCfg.MinimumLedgerLatency,
+			SnapshotInterval: cliCfg.SnapshotInterval,
+			SnapshotURL:      cliCfg.SnapshotURL,
+			LDBPath:          cliCfg.ReflectorConfig.LDBPath, // use the reflector config's ldb path here
+			Reflector:        reflector,                      // compose the reflector, since it will start with the supervisor
+			MaxLedgerLatency: cliCfg.MaxLedgerLatency,
 		})
 		if err != nil {
 			return errors.Wrap(err, "start supervisor")

--- a/pkg/cmd/ctlstore/main.go
+++ b/pkg/cmd/ctlstore/main.go
@@ -86,7 +86,7 @@ type supervisorCliConfig struct {
 	ReflectorConfig     reflectorCliConfig `conf:"reflector" help:"reflector configuration"`
 	Shadow              bool               `conf:"shadow" help:"set this to true to emit shadow=true metric tags"`
 	Dogstatsd           dogstatsdConfig    `conf:"dogstatsd" help:"dogstatsd Configuration"`
-	MaxLedgerLatency    time.Duration      `conf:"minimum-ledger-latency" help:"Minimum ledger latency, at which the supervisor halts snapshots and waits for the ledger to catch up."`
+	MaxLedgerLatency    time.Duration      `conf:"max-ledger-latency" help:"Maximum ledger latency, at which the supervisor halts snapshots and waits for the ledger to catch up."`
 }
 
 // ledgerHealthConfig configures the behavior of the container

--- a/pkg/cmd/ctlstore/main.go
+++ b/pkg/cmd/ctlstore/main.go
@@ -266,7 +266,7 @@ func supervisor(ctx context.Context, args []string) {
 			SnapshotInterval: 5 * time.Minute,
 			Dogstatsd:        defaultDogstatsdConfig(),
 			ReflectorConfig:  reflectorConfig,
-			MaxLedgerLatency: time.Minute,
+			MaxLedgerLatency: 10 * time.Minute,
 		}
 		loadConfig(&cliCfg, "supervisor", args)
 		if cliCfg.Debug {

--- a/pkg/cmd/ctlstore/main.go
+++ b/pkg/cmd/ctlstore/main.go
@@ -302,7 +302,7 @@ func supervisor(ctx context.Context, args []string) {
 			LDBPath:          cliCfg.ReflectorConfig.LDBPath, // use the reflector config's ldb path here
 			Reflector:        reflector,                      // compose the reflector, since it will start with the supervisor
 			MaxLedgerLatency: cliCfg.MaxLedgerLatency,
-			Latencier:        reader,
+			GetLedgerLatency: reader.GetLedgerLatency,
 		})
 		if err != nil {
 			return errors.Wrap(err, "start supervisor")

--- a/pkg/cmd/ctlstore/main.go
+++ b/pkg/cmd/ctlstore/main.go
@@ -292,12 +292,17 @@ func supervisor(ctx context.Context, args []string) {
 			return errors.Wrap(err, "build supervisor reflector")
 		}
 
+		reader, err := ctlstore.ReaderForPath(cliCfg.ReflectorConfig.LDBPath)
+		if err != nil {
+			return errors.Wrap(err, "create supervisor LDB reader")
+		}
 		supervisor, err := supervisorpkg.SupervisorFromConfig(supervisorpkg.SupervisorConfig{
 			SnapshotInterval: cliCfg.SnapshotInterval,
 			SnapshotURL:      cliCfg.SnapshotURL,
 			LDBPath:          cliCfg.ReflectorConfig.LDBPath, // use the reflector config's ldb path here
 			Reflector:        reflector,                      // compose the reflector, since it will start with the supervisor
 			MaxLedgerLatency: cliCfg.MaxLedgerLatency,
+			Latencier:        reader,
 		})
 		if err != nil {
 			return errors.Wrap(err, "start supervisor")

--- a/pkg/supervisor/supervisor_test.go
+++ b/pkg/supervisor/supervisor_test.go
@@ -263,15 +263,12 @@ func TestSupervisorMaximumLedgerLatency(t *testing.T) {
 	sv.Start(sctx)
 
 	_, err = os.Stat(archivePath)
-	if err != nil {
-		t.Fatalf("No archive created")
-	}
+	require.NoError(t, err, "Expected an archive to be created")
 
-	// Now clear the archive file.
+	// Now clear the archive file so we can verify that the supervisor does not
+	// create a snapshot if the ledger latency is too much.
 	err = os.Remove(archivePath)
-	if err != nil {
-		t.Fatalf("Failed to remove archive")
-	}
+	require.NoError(t, err, "Failed to remove archive")
 
 	// Bump up the latency
 	sv.getLedgerLatency = mockGetLedgerLatency(time.Hour, nil)
@@ -290,7 +287,5 @@ func TestSupervisorMaximumLedgerLatency(t *testing.T) {
 	sv.Start(sctx)
 
 	_, err = os.Stat(archivePath)
-	if err == nil {
-		t.Fatalf("Archive created, but not expected")
-	}
+	require.Error(t, err, "Did not expect an archive to be created, due to max ledger latency")
 }


### PR DESCRIPTION
If we were to lose snapshot data in S3, then new reflectors will have to start replaying the full DML ledger from the beginning to recreate an LDB. If this happened, then when the supervisor reboots and starts recreating its LDB, it'll start uploading quite out-of-date snapshots to S3 every 5m. After it uploads its first snapshot, any new reflectors that come online will take that snapshot and start rebuilding their LDB from that point-in-time. That would quickly lead to significant load on the ctldb.

In general, we never want to upload a snapshot unless it is relatively recent. This PR updates the supervisor to inspect its ledger latency when performing a snapshot. The exact limit that it enforces, the maximum ledger latency, is configurable, but will default to `10m`.