### PR TITLE
[F8N-865] [ctlstore] Add ctlstore version to globalstats in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:alpine
-ENV SRC github.com/segmentio/ctlstore
+
 ARG VERSION
+ENV SRC github.com/segmentio/ctlstore
+ENV GO111MODULE on
 
 RUN apk --update add gcc git curl alpine-sdk libc6-compat ca-certificates sqlite \
   && curl -SsL https://github.com/segmentio/chamber/releases/download/v2.1.0/chamber-v2.1.0-linux-amd64 -o /bin/chamber \
@@ -8,11 +10,18 @@ RUN apk --update add gcc git curl alpine-sdk libc6-compat ca-certificates sqlite
 
 COPY . /go/src/${SRC}
 
-RUN CGO_ENABLED=1 go install -ldflags="-X github.com/segmentio/ctlstore.Version=$VERSION" ${SRC}/pkg/cmd/ctlstore \
-  && cp ${GOPATH}/bin/ctlstore /usr/local/bin
+RUN CGO_ENABLED=1 \
+  go install \
+  -ldflags="-X github.com/segmentio/ctlstore.Version=$VERSION -X github.com/segmentio/ctlstore/pkg/globalstats.version=$VERSION" \
+  ${SRC}/pkg/cmd/ctlstore \
+  && \
+  cp ${GOPATH}/bin/ctlstore /usr/local/bin
 
-RUN CGO_ENABLED=1 go install -ldflags="-X github.com/segmentio/ctlstore.Version=$VERSION" ${SRC}/pkg/cmd/ctlstore-cli \
-  && cp ${GOPATH}/bin/ctlstore-cli /usr/local/bin
+RUN CGO_ENABLED=1 go install \
+  -ldflags="-X github.com/segmentio/ctlstore.Version=$VERSION -X github.com/segmentio/ctlstore/pkg/globalstats.version=$VERSION" \
+  ${SRC}/pkg/cmd/ctlstore-cli \
+  && \
+  cp ${GOPATH}/bin/ctlstore-cli /usr/local/bin
 
 RUN apk del gcc git curl alpine-sdk libc6-compat
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:alpine
 ARG VERSION
 ENV SRC github.com/segmentio/ctlstore
 ENV GO111MODULE on
+ENV GO_LDFLAGS "-X github.com/segmentio/ctlstore.Version=$VERSION -X github.com/segmentio/ctlstore/pkg/globalstats.version=$VERSION"
 
 RUN apk --update add gcc git curl alpine-sdk libc6-compat ca-certificates sqlite \
   && curl -SsL https://github.com/segmentio/chamber/releases/download/v2.1.0/chamber-v2.1.0-linux-amd64 -o /bin/chamber \
@@ -10,18 +11,11 @@ RUN apk --update add gcc git curl alpine-sdk libc6-compat ca-certificates sqlite
 
 COPY . /go/src/${SRC}
 
-RUN CGO_ENABLED=1 \
-  go install \
-  -ldflags="-X github.com/segmentio/ctlstore.Version=$VERSION -X github.com/segmentio/ctlstore/pkg/globalstats.version=$VERSION" \
-  ${SRC}/pkg/cmd/ctlstore \
-  && \
-  cp ${GOPATH}/bin/ctlstore /usr/local/bin
+RUN CGO_ENABLED=1 go install -ldflags="${GO_LDFLAGS}" ${SRC}/pkg/cmd/ctlstore \
+  && cp ${GOPATH}/bin/ctlstore /usr/local/bin
 
-RUN CGO_ENABLED=1 go install \
-  -ldflags="-X github.com/segmentio/ctlstore.Version=$VERSION -X github.com/segmentio/ctlstore/pkg/globalstats.version=$VERSION" \
-  ${SRC}/pkg/cmd/ctlstore-cli \
-  && \
-  cp ${GOPATH}/bin/ctlstore-cli /usr/local/bin
+RUN CGO_ENABLED=1 go install -ldflags="${GO_LDFLAGS}" ${SRC}/pkg/cmd/ctlstore-cli \
+  && cp ${GOPATH}/bin/ctlstore-cli /usr/local/bin
 
 RUN apk del gcc git curl alpine-sdk libc6-compat
 


### PR DESCRIPTION
This is a follow-up PR to https://github.com/segmentio/ctlstore/pull/20 which sets the `globalstats.version` tag at compile-time.

We previously just did this in the `Makefile`: https://github.com/segmentio/ctlstore/pull/20/files?file-filters%5B%5D=.go&file-filters%5B%5D=No+extension#diff-b67911656ef5d18c4ae36cb6741b7965R28

