### PR TITLE
Fix goroutine growth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 FROM golang:alpine
-
-ARG VERSION
 ENV SRC github.com/segmentio/ctlstore
-ENV GO111MODULE on
-ENV GO_LDFLAGS "-X github.com/segmentio/ctlstore.Version=$VERSION -X github.com/segmentio/ctlstore/pkg/globalstats.version=$VERSION"
+ARG VERSION
 
 RUN apk --update add gcc git curl alpine-sdk libc6-compat ca-certificates sqlite \
   && curl -SsL https://github.com/segmentio/chamber/releases/download/v2.1.0/chamber-v2.1.0-linux-amd64 -o /bin/chamber \
@@ -11,10 +8,10 @@ RUN apk --update add gcc git curl alpine-sdk libc6-compat ca-certificates sqlite
 
 COPY . /go/src/${SRC}
 
-RUN CGO_ENABLED=1 go install -ldflags="${GO_LDFLAGS}" ${SRC}/pkg/cmd/ctlstore \
+RUN CGO_ENABLED=1 go install -ldflags="-X github.com/segmentio/ctlstore.Version=$VERSION" ${SRC}/pkg/cmd/ctlstore \
   && cp ${GOPATH}/bin/ctlstore /usr/local/bin
 
-RUN CGO_ENABLED=1 go install -ldflags="${GO_LDFLAGS}" ${SRC}/pkg/cmd/ctlstore-cli \
+RUN CGO_ENABLED=1 go install -ldflags="-X github.com/segmentio/ctlstore.Version=$VERSION" ${SRC}/pkg/cmd/ctlstore-cli \
   && cp ${GOPATH}/bin/ctlstore-cli /usr/local/bin
 
 RUN apk del gcc git curl alpine-sdk libc6-compat

--- a/pkg/cmd/ctlstore/main.go
+++ b/pkg/cmd/ctlstore/main.go
@@ -86,7 +86,6 @@ type supervisorCliConfig struct {
 	ReflectorConfig     reflectorCliConfig `conf:"reflector" help:"reflector configuration"`
 	Shadow              bool               `conf:"shadow" help:"set this to true to emit shadow=true metric tags"`
 	Dogstatsd           dogstatsdConfig    `conf:"dogstatsd" help:"dogstatsd Configuration"`
-	MaxLedgerLatency    time.Duration      `conf:"max-ledger-latency" help:"Maximum ledger latency, at which the supervisor halts snapshots and waits for the ledger to catch up."`
 }
 
 // ledgerHealthConfig configures the behavior of the container
@@ -266,7 +265,6 @@ func supervisor(ctx context.Context, args []string) {
 			SnapshotInterval: 5 * time.Minute,
 			Dogstatsd:        defaultDogstatsdConfig(),
 			ReflectorConfig:  reflectorConfig,
-			MaxLedgerLatency: 10 * time.Minute,
 		}
 		loadConfig(&cliCfg, "supervisor", args)
 		if cliCfg.Debug {
@@ -297,19 +295,6 @@ func supervisor(ctx context.Context, args []string) {
 			SnapshotURL:      cliCfg.SnapshotURL,
 			LDBPath:          cliCfg.ReflectorConfig.LDBPath, // use the reflector config's ldb path here
 			Reflector:        reflector,                      // compose the reflector, since it will start with the supervisor
-			MaxLedgerLatency: cliCfg.MaxLedgerLatency,
-			GetLedgerLatency: func(ctx context.Context) (time.Duration, error) {
-				// Construct a new reader on each call to GetLedgerLatency, since the
-				// LDB may not exist yet. In that case, we just want to surface an error
-				// to the supervisor itself so it can decide how to handle it, instead of
-				// failing on start up.
-				reader, err := ctlstore.ReaderForPath(cliCfg.ReflectorConfig.LDBPath)
-				if err != nil {
-					return 0, errors.Wrap(err, "create supervisor LDB reader")
-				}
-
-				return reader.GetLedgerLatency(ctx)
-			},
 		})
 		if err != nil {
 			return errors.Wrap(err, "start supervisor")

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -29,28 +29,17 @@ type SupervisorConfig struct {
 	SnapshotURL      string
 	LDBPath          string
 	Reflector        Reflector
-	MaxLedgerLatency time.Duration
-	GetLedgerLatency func(ctx context.Context) (time.Duration, error)
 }
 
 type supervisor struct {
-	SleepDuration    time.Duration
-	BreatheDuration  time.Duration
-	LDBPath          string
-	Snapshots        []archivedSnapshot
-	reflectorCtl     *reflector.ReflectorCtl
-	getLedgerLatency func(ctx context.Context) (time.Duration, error)
-	maxLedgerLatency time.Duration
+	SleepDuration   time.Duration
+	BreatheDuration time.Duration
+	LDBPath         string
+	Snapshots       []archivedSnapshot
+	reflectorCtl    *reflector.ReflectorCtl
 }
 
 func SupervisorFromConfig(config SupervisorConfig) (Supervisor, error) {
-	if config.GetLedgerLatency == nil {
-		return nil, errors.New("GetLedgerLatency func is required")
-	}
-	if config.MaxLedgerLatency == 0 {
-		return nil, errors.New("max ledger latency is required")
-	}
-
 	var snapshots []archivedSnapshot
 	urls := strings.Split(config.SnapshotURL, ",")
 	for _, url := range urls {
@@ -60,15 +49,12 @@ func SupervisorFromConfig(config SupervisorConfig) (Supervisor, error) {
 		}
 		snapshots = append(snapshots, snapshot)
 	}
-
 	return &supervisor{
-		SleepDuration:    config.SnapshotInterval,
-		BreatheDuration:  5 * time.Second,
-		LDBPath:          config.LDBPath,
-		Snapshots:        snapshots,
-		reflectorCtl:     reflector.NewReflectorCtl(config.Reflector),
-		getLedgerLatency: config.GetLedgerLatency,
-		maxLedgerLatency: config.MaxLedgerLatency,
+		SleepDuration:   config.SnapshotInterval,
+		BreatheDuration: 5 * time.Second,
+		LDBPath:         config.LDBPath,
+		Snapshots:       snapshots,
+		reflectorCtl:    reflector.NewReflectorCtl(config.Reflector),
 	}, nil
 }
 
@@ -144,33 +130,14 @@ func (s *supervisor) Start(ctx context.Context) {
 	s.reflectorCtl.Start(ctx)
 	defer events.Log("Stopped Supervisor")
 	for {
-		err := func() error {
-			// If the ledger latency is too much, temporarily stop uploading snapshots.
-			// We need to first catch up, or else we'll upload snapshots that are out-of-date
-			// which would put a significant amount of load on the exective because every new
-			// reflector will have to sync a potentially very large chunk of the DML ledger.
-			latency, err := s.getLedgerLatency(ctx)
-			if err != nil {
-				return err
-			}
-			isAcceptableLatency := s.maxLedgerLatency > latency
-
-			if !isAcceptableLatency {
-				stats.Incr("snapshot_skipped")
-				events.Log("Supervisor LDB is out-of-date; skipping snapshot (latency = %{latency}v, maximum latency allowed = %{maxLedgerLatency}v)", latency, s.maxLedgerLatency)
-				return nil
-			}
-
-			return s.snapshot(ctx)
-		}()
 		sleepDur := s.SleepDuration
+		err := s.snapshot(ctx)
 		if err != nil && errors.Cause(err) != context.Canceled {
 			s.incrementSnapshotErrorMetric(1)
 			events.Log("Error taking snapshot: %{error}+v", err)
 			// Use a shorter sleep duration for faster retries
 			sleepDur = s.BreatheDuration
 		}
-
 		select {
 		case <-time.After(sleepDur):
 		case <-ctx.Done():

--- a/pkg/supervisor/supervisor_test.go
+++ b/pkg/supervisor/supervisor_test.go
@@ -10,25 +10,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	ldbpkg "github.com/segmentio/ctlstore/pkg/ldb"
 	"github.com/segmentio/ctlstore/pkg/reflector/fakes"
 	"github.com/stretchr/testify/require"
 )
 
-// Helper for building a GetLedgerLatency func.
-func mockGetLedgerLatency(duration time.Duration, err error) func(ctx context.Context) (time.Duration, error) {
-	return func(ctx context.Context) (time.Duration, error) {
-		return duration, err
-	}
-}
-
 func TestSupervisorParsingSnapshotURL(t *testing.T) {
 	urls := "s3://segment-ctlstore-snapshots-stage/snapshot.db.gz,s3://segment-ctlstore-snapshots-stage/snapshot.db"
 	sup, err := SupervisorFromConfig(SupervisorConfig{
-		SnapshotURL:      urls,
-		GetLedgerLatency: mockGetLedgerLatency(time.Second, nil),
-		MaxLedgerLatency: time.Minute,
+		SnapshotURL: urls,
 	})
 	require.NoError(t, err)
 	supi, ok := sup.(*supervisor)
@@ -52,8 +42,6 @@ func TestSupervisor(t *testing.T) {
 	ldbDbPath := filepath.Join(tmpPath, "ldb.db")
 	archivePath := filepath.Join(tmpPath, "archive.db")
 
-	expectedSeqNumber := 100
-
 	reflector := fakes.NewFakeReflector()
 	defer func() {
 		// reflector should not be running
@@ -67,8 +55,6 @@ func TestSupervisor(t *testing.T) {
 		SnapshotURL:      "file://" + archivePath,
 		LDBPath:          ldbDbPath,
 		Reflector:        reflector,
-		GetLedgerLatency: mockGetLedgerLatency(time.Second, nil),
-		MaxLedgerLatency: time.Minute,
 	}
 
 	sv, err := SupervisorFromConfig(cfg)
@@ -86,7 +72,7 @@ func TestSupervisor(t *testing.T) {
 
 	_, err = ldb.Exec(
 		fmt.Sprintf("REPLACE INTO %s (id, seq) VALUES(?, ?)", ldbpkg.LDBSeqTableName),
-		ldbpkg.LDBSeqTableID, expectedSeqNumber)
+		ldbpkg.LDBSeqTableID, 100)
 	require.NoError(t, err)
 
 	sctx, scancel := context.WithTimeout(ctx, 1*time.Second)
@@ -169,7 +155,7 @@ func TestSupervisor(t *testing.T) {
 	var gotSeq int
 	err = row.Scan(&gotSeq)
 	require.NoError(t, err)
-	require.EqualValues(t, expectedSeqNumber, gotSeq)
+	require.EqualValues(t, 100, gotSeq)
 }
 
 // verifies that the embedded reflector is properly shutdown
@@ -196,8 +182,6 @@ func TestSupervisorSnapshotReflectorCtl(t *testing.T) {
 		SnapshotURL:      "file://" + archivePath,
 		LDBPath:          ldbDbPath,
 		Reflector:        reflector,
-		GetLedgerLatency: mockGetLedgerLatency(time.Second, nil),
-		MaxLedgerLatency: time.Minute,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, supervisorI)
@@ -225,87 +209,4 @@ func TestSupervisorSnapshotReflectorCtl(t *testing.T) {
 	// verify no more events (steady state)
 	time.Sleep(100 * time.Millisecond)
 	require.Equal(t, 0, len(reflector.Events))
-}
-
-func TestSupervisorMaximumLedgerLatency(t *testing.T) {
-	tmpPath, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpPath)
-	ldbDbPath := filepath.Join(tmpPath, "ldb.db")
-	archivePath := filepath.Join(tmpPath, "archive.db")
-
-	svI, err := SupervisorFromConfig(SupervisorConfig{
-		SnapshotInterval: 100 * time.Millisecond,
-		SnapshotURL:      "file://" + archivePath,
-		LDBPath:          ldbDbPath,
-		Reflector:        fakes.NewFakeReflector(),
-		GetLedgerLatency: mockGetLedgerLatency(time.Second, nil),
-		MaxLedgerLatency: time.Minute,
-	})
-	require.NoError(t, err)
-	sv := svI.(*supervisor)
-	defer sv.Close()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	sctx, scancel := context.WithTimeout(ctx, 1*time.Second)
-	defer scancel()
-
-	go func() {
-		// Wait for snapshot to complete
-		time.Sleep(10 * time.Millisecond)
-		// Cancels the context passed to the supervisor, which should cause it
-		// to return from the Start() call
-		scancel()
-	}()
-
-	// This should create a snapshot because the latency is below the max. An archive file should be created.
-	sv.Start(sctx)
-
-	_, err = os.Stat(archivePath)
-	require.NoError(t, err, "Expected an archive to be created")
-
-	// Now clear the archive file so we can verify that the supervisor does not
-	// create a snapshot if the ledger latency is too much.
-	err = os.Remove(archivePath)
-	require.NoError(t, err, "Failed to remove archive")
-
-	// Bump up the latency
-	sv.getLedgerLatency = mockGetLedgerLatency(time.Hour, nil)
-
-	sctx, scancel = context.WithTimeout(ctx, 1*time.Second)
-	defer scancel()
-	go func() {
-		// Wait for snapshot to complete
-		time.Sleep(10 * time.Millisecond)
-		// Cancels the context passed to the supervisor, which should cause it
-		// to return from the Start() call
-		scancel()
-	}()
-
-	// This should skip a snapshot because of the latency, we don't expect an archive to be created.
-	sv.Start(sctx)
-
-	_, err = os.Stat(archivePath)
-	require.Error(t, err, "Did not expect an archive to be created, due to max ledger latency")
-
-	// Return an error from GetLedgerLatency
-	sv.getLedgerLatency = mockGetLedgerLatency(time.Minute, errors.New("Oops"))
-
-	sctx, scancel = context.WithTimeout(ctx, 1*time.Second)
-	defer scancel()
-	go func() {
-		// Wait for snapshot to complete
-		time.Sleep(10 * time.Millisecond)
-		// Cancels the context passed to the supervisor, which should cause it
-		// to return from the Start() call
-		scancel()
-	}()
-
-	// This should skip a snapshot because of the error, we don't expect an archive to be created.
-	sv.Start(sctx)
-
-	_, err = os.Stat(archivePath)
-	require.Error(t, err, "Did not expect an archive to be created, due to max ledger latency")
 }


### PR DESCRIPTION
The commit to halt snapshots of the supervisor when the ledger latency was past a threshold ended up causing some unbounded goroutine growth.  This PR reverts that commit as well as the one that followed it in order to correct the behavior.

Once the issue is worked out, we can un-revert those changes and apply the fix and then re-release it.