### PR TITLE
Reflector prometheus

### DIFF
--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -67,6 +67,8 @@ services:
       build:
         context: .
         dockerfile: Dockerfile
+      ports:
+        - 9090:9090
       entrypoint:
         - /usr/local/bin/ctlstore
         - reflector
@@ -81,6 +83,8 @@ services:
         - -upstream-dsn
         - ctldb:ctldbpw@tcp(mysql:3306)/ctldb?collation=utf8mb4_unicode_ci
         - -ledger-latency.disable # no ECS in a docker-compose environment
+        - -metrics-bind
+        - 0.0.0.0:9090
       volumes:
         - ldb:/var/spool/ctlstore
 

--- a/pkg/cmd/ctlstore/main.go
+++ b/pkg/cmd/ctlstore/main.go
@@ -293,6 +293,7 @@ func supervisor(ctx context.Context, args []string) {
 			http.Handle("/metrics", promHandler)
 
 			go func() {
+				events.Log("Serving Prometheus metrics on %s", reflectorConfig.MetricsBind)
 				http.ListenAndServe(reflectorConfig.MetricsBind, nil)
 			}()
 		}


### PR DESCRIPTION
This change adds a Prometheus Handler to serve the metrics via an http handler. I've only added this handler on the reflector so far.