### PR TITLE
[F8N-1606] Add support for LDB versioning

### DIFF
--- a/initialize.go
+++ b/initialize.go
@@ -19,7 +19,7 @@ type Config struct {
 	// hot-reload new LDBs as they appear.
 	//
 	// By default, this is disabled.
-	LDBVersioning *bool
+	LDBVersioning bool
 }
 
 var ldbVersioning bool
@@ -36,9 +36,7 @@ func InitializeWithConfig(ctx context.Context, cfg Config) {
 		// Initialize globalstats with the provided configuration:
 		globalstats.Initialize(ctx, *cfg.Stats)
 	}
-	if cfg.LDBVersioning != nil {
-		ldbVersioning = *cfg.LDBVersioning
-	}
+	ldbVersioning = cfg.LDBVersioning
 }
 
 // Initialize sets up global state for thing including global

--- a/initialize.go
+++ b/initialize.go
@@ -8,8 +8,21 @@ import (
 )
 
 type Config struct {
-	Stats globalstats.Config
+	// Stats specifies the config for reporting stats to the global
+	// ctlstore stats namespace.
+	//
+	// By default, global stats are enabled with a set of sane defaults.
+	Stats *globalstats.Config
+
+	// LDBVersioning, if enabled, will instruct ctlstore to look for
+	// LDBs inside of timestamp-delimited folders, and ctlstore will
+	// hot-reload new LDBs as they appear.
+	//
+	// By default, this is disabled.
+	LDBVersioning *bool
 }
+
+var ldbVersioning bool
 
 func init() {
 	// Enable globalstats by default.
@@ -19,8 +32,13 @@ func init() {
 // InitializeWithConfig sets up global state for thing including global
 // metrics globalstats data and possibly more as time goes on.
 func InitializeWithConfig(ctx context.Context, cfg Config) {
-	// Initialize globalstats with the provided configuration:
-	globalstats.Initialize(ctx, cfg.Stats)
+	if cfg.Stats != nil {
+		// Initialize globalstats with the provided configuration:
+		globalstats.Initialize(ctx, *cfg.Stats)
+	}
+	if cfg.LDBVersioning != nil {
+		ldbVersioning = *cfg.LDBVersioning
+	}
 }
 
 // Initialize sets up global state for thing including global

--- a/ldb.go
+++ b/ldb.go
@@ -1,7 +1,6 @@
 package ctlstore
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -16,7 +15,7 @@ const (
 )
 
 var (
-	globalLDBPath     = filepath.Join(DefaultCtlstorePath, ldb.DefaultLDBFilename)
+	globalLDBDirPath  = DefaultCtlstorePath
 	globalCLPath      = filepath.Join(DefaultCtlstorePath, DefaultChangelogFilename)
 	globalLDBReadOnly = true
 	globalReader      *LDBReader
@@ -26,7 +25,7 @@ var (
 func init() {
 	envPath := os.Getenv("CTLSTORE_PATH")
 	if envPath != "" {
-		globalLDBPath = filepath.Join(envPath, ldb.DefaultLDBFilename)
+		globalLDBDirPath = envPath
 		globalCLPath = filepath.Join(envPath, DefaultChangelogFilename)
 	}
 	sqlite.InitDriver()
@@ -35,24 +34,7 @@ func init() {
 // ReaderForPath opens an LDB at the provided path and returns an LDBReader
 // instance pointed at that LDB.
 func ReaderForPath(path string) (*LDBReader, error) {
-	_, err := os.Stat(path)
-	switch {
-	case os.IsNotExist(err):
-		return nil, fmt.Errorf("no LDB found at %s", path)
-	case err != nil:
-		return nil, err
-	}
-
-	mode := "ro"
-	if !globalLDBReadOnly {
-		mode = "rwc"
-	}
-
-	ldb, err := ldb.OpenLDB(path, mode)
-	if err != nil {
-		return nil, err
-	}
-	return &LDBReader{Db: ldb}, nil
+	return newLDBReader(path)
 }
 
 // Reader returns an LDBReader that can be used globally.
@@ -67,7 +49,13 @@ func Reader() (*LDBReader, error) {
 		defer globalReaderMu.Unlock()
 
 		if globalReader == nil {
-			reader, err := ReaderForPath(globalLDBPath)
+			var reader *LDBReader
+			var err error
+			if ldbVersioning {
+				reader, err = newVersionedLDBReader(globalLDBDirPath)
+			} else {
+				reader, err = newLDBReader(filepath.Join(globalLDBDirPath, ldb.DefaultLDBFilename))
+			}
 			if err != nil {
 				return nil, err
 			}

--- a/ldb.go
+++ b/ldb.go
@@ -10,22 +10,25 @@ import (
 )
 
 const (
-	DefaultCtlstorePath      = "/var/spool/ctlstore/"
-	DefaultChangelogFilename = "change.log"
+	DefaultCtlstorePath        = "/var/spool/ctlstore/"
+	DefaultChangelogFilename   = "change.log"
+	defaultLDBVersioningSubdir = "versioned"
 )
 
 var (
-	globalLDBDirPath  = DefaultCtlstorePath
-	globalCLPath      = filepath.Join(DefaultCtlstorePath, DefaultChangelogFilename)
-	globalLDBReadOnly = true
-	globalReader      *LDBReader
-	globalReaderMu    sync.RWMutex
+	globalLDBDirPath           = DefaultCtlstorePath
+	globalLDBVersioningDirPath = filepath.Join(DefaultCtlstorePath, defaultLDBVersioningSubdir)
+	globalCLPath               = filepath.Join(DefaultCtlstorePath, DefaultChangelogFilename)
+	globalLDBReadOnly          = true
+	globalReader               *LDBReader
+	globalReaderMu             sync.RWMutex
 )
 
 func init() {
 	envPath := os.Getenv("CTLSTORE_PATH")
 	if envPath != "" {
 		globalLDBDirPath = envPath
+		globalLDBVersioningDirPath = filepath.Join(envPath, defaultLDBVersioningSubdir)
 		globalCLPath = filepath.Join(envPath, DefaultChangelogFilename)
 	}
 	sqlite.InitDriver()
@@ -52,7 +55,7 @@ func Reader() (*LDBReader, error) {
 			var reader *LDBReader
 			var err error
 			if ldbVersioning {
-				reader, err = newVersionedLDBReader(globalLDBDirPath)
+				reader, err = newVersionedLDBReader(globalLDBVersioningDirPath)
 			} else {
 				reader, err = newLDBReader(filepath.Join(globalLDBDirPath, ldb.DefaultLDBFilename))
 			}

--- a/ldb_reader.go
+++ b/ldb_reader.go
@@ -577,7 +577,6 @@ func (reader *LDBReader) getGetRowByKeyStmt(ctx context.Context, pk schema.Prima
 }
 
 func (reader *LDBReader) watchForLDBs(ctx context.Context, dirPath string, last int64) {
-	// TODO: consider using a fs notification library instead of polling.
 	ticker := time.NewTicker(time.Second)
 
 	for {

--- a/ldb_reader.go
+++ b/ldb_reader.go
@@ -3,16 +3,22 @@ package ctlstore
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/segmentio/ctlstore/pkg/errs"
 	"github.com/segmentio/ctlstore/pkg/globalstats"
 	"github.com/segmentio/ctlstore/pkg/ldb"
 	"github.com/segmentio/ctlstore/pkg/scanfunc"
 	"github.com/segmentio/ctlstore/pkg/schema"
 	"github.com/segmentio/ctlstore/pkg/sqlgen"
 	"github.com/segmentio/errors-go"
+	"github.com/segmentio/events"
 	"github.com/segmentio/stats/v4"
 )
 
@@ -25,6 +31,7 @@ type LDBReader struct {
 	getRowByKeyStmtCache        map[string]*sql.Stmt         // keyed by ldbTableName()
 	getRowsByKeyPrefixStmtCache map[prefixCacheKey]*sql.Stmt
 	mu                          sync.RWMutex
+	cancelWatcher               context.CancelFunc
 }
 
 type prefixCacheKey struct {
@@ -37,6 +44,63 @@ var (
 	ErrNeedFullKey          = errors.New("All primary key fields are required")
 	ErrNoLedgerUpdates      = errors.New("no ledger updates have been received yet")
 )
+
+func newLDBReader(path string) (*LDBReader, error) {
+	db, err := newLDB(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &LDBReader{Db: db}, nil
+}
+
+func newVersionedLDBReader(dirPath string) (*LDBReader, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	reader := &LDBReader{
+		cancelWatcher: cancel,
+	}
+
+	// To initialize this reader, we must first load an LDB:
+	last, err := lookupLastLDBSync(dirPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "checking last ldb sync")
+	}
+	if last == 0 {
+		return nil, fmt.Errorf("no LDB in path (%s)", dirPath)
+	}
+	err = reader.switchToLDB(dirPath, last)
+	if err != nil {
+		return nil, errors.Wrap(err, "switching ldbs")
+	}
+
+	// Then we can defer to the watcher goroutine to swap this
+	// reader LDB if a newer one appears:
+	go reader.watchForLDBs(ctx, dirPath, last)
+
+	return reader, nil
+}
+
+func newLDB(path string) (*sql.DB, error) {
+	_, err := os.Stat(path)
+	switch {
+	case os.IsNotExist(err):
+		return nil, fmt.Errorf("no LDB found at %s", path)
+	case err != nil:
+		return nil, err
+	}
+
+	mode := "ro"
+	if !globalLDBReadOnly {
+		mode = "rwc"
+	}
+
+	db, err := ldb.OpenLDB(path, mode)
+	if err != nil {
+		return nil, err
+	}
+
+	return db, nil
+}
 
 // Constructs an LDBReader from a sql.DB. Really only useful for testing.
 func NewLDBReaderFromDB(db *sql.DB) *LDBReader {
@@ -244,14 +308,30 @@ func (reader *LDBReader) Close() error {
 	reader.mu.Lock()
 	defer reader.mu.Unlock()
 
+	if reader.cancelWatcher != nil {
+		reader.cancelWatcher()
+	}
+
+	return reader.closeDB()
+}
+
+// closeDB closes all reader-owned resources associated with the current DB.
+// It should only be called when the caller is holding the reader.mu mutex.
+func (reader *LDBReader) closeDB() error {
 	for _, stmt := range reader.getRowByKeyStmtCache {
 		stmt.Close()
 	}
+	reader.getRowByKeyStmtCache = map[string]*sql.Stmt{}
 	for _, stmt := range reader.getRowsByKeyPrefixStmtCache {
 		stmt.Close()
 	}
+	reader.getRowsByKeyPrefixStmtCache = map[prefixCacheKey]*sql.Stmt{}
 
-	return reader.Db.Close()
+	if reader.Db != nil {
+		return reader.Db.Close()
+	}
+
+	return nil
 }
 
 // Ping checks if the LDB is available
@@ -489,4 +569,111 @@ func (reader *LDBReader) getGetRowByKeyStmt(ctx context.Context, pk schema.Prima
 	}
 
 	return stmt, err
+}
+
+func (reader *LDBReader) watchForLDBs(ctx context.Context, dirPath string, last int64) {
+	// TODO: consider using a fs notification library instead of polling.
+	ticker := time.NewTicker(time.Second)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			fsLast, err := lookupLastLDBSync(dirPath)
+			if err != nil {
+				events.Log("failed checking for last LDB sync: %{error}+v", err)
+				errs.Incr("check-last-ldb-sync")
+				continue
+			}
+
+			// Only swap LDBs if this LDB is newer than our newest LDB.
+			if fsLast <= last {
+				continue
+			}
+			events.Log("found new LDB (%d > %d), switching...", fsLast, last)
+			last = fsLast
+
+			err = reader.switchToLDB(dirPath, last)
+			if err != nil {
+				events.Log("failed switching to new LDB: %{error}+v", err)
+				errs.Incr("switch-ldb")
+			}
+		}
+	}
+}
+
+func (reader *LDBReader) switchToLDB(dirPath string, timestamp int64) error {
+	fullPath := filepath.Join(dirPath, fmt.Sprintf("%013d", timestamp), ldb.DefaultLDBFilename)
+
+	db, err := newLDB(fullPath)
+	if err != nil {
+		return errors.Wrap(err, "new ldb")
+	}
+
+	reader.mu.Lock()
+	defer reader.mu.Unlock()
+
+	if err = reader.closeDB(); err != nil {
+		return errors.Wrap(err, "closing db")
+	}
+
+	reader.Db = db
+
+	return nil
+}
+
+func lookupLastLDBSync(dirPath string) (int64, error) {
+	// Loop through the files in the `dirPath` and look for the ldb.db with the
+	// highest associated timestamp. Return that.
+	var lastSync int64
+	err := filepath.Walk(dirPath, func(filePath string, info os.FileInfo, _ error) error {
+		// Ignore directories:
+		if info.IsDir() {
+			return nil
+		}
+
+		// We only care about the timestamps associated with `<path>/<timestamp>/ldb.db` files.
+		// Therefore, we ignore all other files (ldb.db.wal, etc).
+		if !strings.HasSuffix(filePath, ldb.DefaultLDBFilename) {
+			return nil
+		}
+
+		// Ignore `<path>/ldb.db`, which is the standard path for LDBs. We only care
+		// about versioned LDBs, which are those in a timestamped directory.
+		if strings.HasPrefix(filePath, filepath.Join(dirPath, ldb.DefaultLDBFilename)) {
+			return nil
+		}
+
+		// Omit the root path from the file path:
+		// dirPath + ["<timestamp>", ldb.DefaultLDBFilename]
+		localPath, err := filepath.Rel(dirPath, filePath)
+		if err != nil {
+			return errors.Wrapf(err, "base path (%s)", filePath)
+		}
+		fields := strings.Split(localPath, "/")
+
+		if len(fields) != 2 || fields[1] != ldb.DefaultLDBFilename {
+			events.Log("ignoring unexpected file in LDB path (%+v)", fields)
+			errs.Incr("unexpected-local-file")
+			return nil
+		}
+		timestamp, err := strconv.ParseInt(fields[0], 10, 64)
+		if err != nil {
+			events.Log("ignoring file with invalid timestamp in LDB path (%+v)", fields)
+			errs.Incr("invalid-timestamp-local-file")
+			return nil
+		}
+
+		if timestamp > lastSync {
+			lastSync = timestamp
+		}
+
+		return nil
+	})
+	if err != nil {
+		return 0, errors.Wrap(err, "filepath walk")
+	}
+
+	return lastSync, nil
 }

--- a/ldb_reader.go
+++ b/ldb_reader.go
@@ -324,11 +324,15 @@ func (reader *LDBReader) Close() error {
 // It should only be called when the caller is holding the reader.mu mutex.
 func (reader *LDBReader) closeDB() error {
 	for _, stmt := range reader.getRowByKeyStmtCache {
-		stmt.Close()
+		if err := stmt.Close(); err != nil {
+			return err
+		}
 	}
 	reader.getRowByKeyStmtCache = map[string]*sql.Stmt{}
 	for _, stmt := range reader.getRowsByKeyPrefixStmtCache {
-		stmt.Close()
+		if err := stmt.Close(); err != nil {
+			return err
+		}
 	}
 	reader.getRowsByKeyPrefixStmtCache = map[prefixCacheKey]*sql.Stmt{}
 

--- a/ldb_reader.go
+++ b/ldb_reader.go
@@ -89,15 +89,15 @@ func newLDB(path string) (*sql.DB, error) {
 		return nil, err
 	}
 
-	mode := "ro"
-	if !globalLDBReadOnly {
-		mode = "rwc"
-	}
-
 	var db *sql.DB
 	if ldbVersioning {
 		db, err = ldb.OpenImmutableLDB(path)
 	} else {
+		mode := "ro"
+		if !globalLDBReadOnly {
+			mode = "rwc"
+		}
+
 		db, err = ldb.OpenLDB(path, mode)
 	}
 	if err != nil {

--- a/ldb_testing.go
+++ b/ldb_testing.go
@@ -24,13 +24,14 @@ func NewLDBTestUtil(t testing.TB) (*LDBTestUtil, func()) {
 		t.Fatal(err)
 	}
 
-	globalLDBPath = filepath.Join(tmpDir, ldb.DefaultLDBFilename)
+	globalLDBDirPath = tmpDir
+	path := filepath.Join(tmpDir, ldb.DefaultLDBFilename)
 	globalLDBReadOnly = false
 	globalReader = nil
 
 	db, err := sql.Open(ldb.LDBDatabaseDriver, fmt.Sprintf(
 		"file:%s?_journal_mode=wal&mode=%s&cache=shared",
-		globalLDBPath,
+		path,
 		"rwc",
 	))
 	if err != nil {

--- a/pkg/ldb/ldbs.go
+++ b/pkg/ldb/ldbs.go
@@ -73,6 +73,10 @@ func OpenLDB(path string, mode string) (*sql.DB, error) {
 		fmt.Sprintf("file:%s?_journal_mode=wal&mode=%s", path, mode))
 }
 
+func OpenImmutableLDB(path string) (*sql.DB, error) {
+	return sql.Open("sqlite3_with_autocheckpoint_off", fmt.Sprintf("file:%s?immutable=true", path))
+}
+
 // Ensures the LDB is prepared for queries
 func EnsureLdbInitialized(ctx context.Context, db *sql.DB) error {
 	for _, statement := range ldbInitializeDDLs {


### PR DESCRIPTION
Currently, updates to an LDB are streamed as SQL mutations from a local reflector daemon process which reads mutations from the `ctldb` ledger.

This PR adds an alternative mechanism for updating LDBs -- versioning. When the `LDBVersioning` flag is enabled, ctlstore readers will monitor for new LDBs inside of the configured folder (by default, `/var/spool/ctlstore`) where the LDBs are stored in timestamped folders, like so:

```sh
# Before
/var/spool/ctlstore/ldb.db

# After
/var/spool/ctlstore/1500000000000/ldb.db
/var/spool/ctlstore/1500000000001/ldb.db
/var/spool/ctlstore/1500000000002/ldb.db
```

This allows you to roll your own mechanism for reflecting LDBs, say from S3. 

## Test / Deployment Plan

No associated deployment.
