### PR TITLE
Add `sqlgen.BatchInsertDML` for bulk inserting LDB rows

### DIFF
--- a/pkg/sqlgen/sqlgen.go
+++ b/pkg/sqlgen/sqlgen.go
@@ -226,10 +226,6 @@ func (t *MetaTable) UpsertDML(values []interface{}) (string, error) {
 
 // Returns the DML string for an 'Insert' for a batch of provided values.
 // We use this to build custom LDBs in bulk where we are not streaming individual writes.
-//
-// Keep in mind that `BatchInsertDML` differs from `UpsertDML` in that it does not expect
-// any values to be base64 encoded since this is not used for streaming use-cases, where
-// values are read from dbz.
 func (t *MetaTable) BatchInsertDML(rows [][]interface{}) (string, error) {
 	if len(rows) == 0 {
 		return "", errors.New("assertion failed: expected at least one row to insert")
@@ -259,17 +255,11 @@ func (t *MetaTable) BatchInsertDML(rows [][]interface{}) (string, error) {
 				buf.WriteString(",")
 			}
 
-			// TODO(colinking): I'm seeing some odd serialization behavior after removing
-			// these lines so I'm bringing them back as a test. Notably this does convert
-			// bytestrings + binary from strings to []byte, so if we remove this then we'll
-			// need to retain that functionality. TBD
 			val, err := maybeDecodeBase64(val,
 				isBase64EncodedFieldType(t.Fields[i].FieldType))
 			if err != nil {
 				return "", err
 			}
-			// -----------------------------------------------------------------------------
-
 			quoted, err := SQLQuote(val)
 			if err != nil {
 				return "", err

--- a/pkg/sqlgen/sqlgen.go
+++ b/pkg/sqlgen/sqlgen.go
@@ -259,6 +259,17 @@ func (t *MetaTable) BatchInsertDML(rows [][]interface{}) (string, error) {
 				buf.WriteString(",")
 			}
 
+			// TODO(colinking): I'm seeing some odd serialization behavior after removing
+			// these lines so I'm bringing them back as a test. Notably this does convert
+			// bytestrings + binary from strings to []byte, so if we remove this then we'll
+			// need to retain that functionality. TBD
+			val, err := maybeDecodeBase64(val,
+				isBase64EncodedFieldType(t.Fields[i].FieldType))
+			if err != nil {
+				return "", err
+			}
+			// -----------------------------------------------------------------------------
+
 			quoted, err := SQLQuote(val)
 			if err != nil {
 				return "", err

--- a/pkg/sqlgen/sqlgen_test.go
+++ b/pkg/sqlgen/sqlgen_test.go
@@ -245,6 +245,114 @@ func TestMetaTableUpsertDML(t *testing.T) {
 	}
 }
 
+func TestMetaTableBatchInsertDML(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		meta func() MetaTable
+		rows [][]interface{}
+		want string
+	}{
+		{
+			name: "basic test",
+			meta: func() MetaTable {
+				famName, _ := schema.NewFamilyName("family1")
+				tblName, _ := schema.NewTableName("table1")
+				return MetaTable{
+					FamilyName: famName,
+					TableName:  tblName,
+					Fields: []schema.NamedFieldType{
+						{schema.FieldName{Name: "field1"}, schema.FTString},
+						{schema.FieldName{Name: "field2"}, schema.FTString},
+						{schema.FieldName{Name: "field3"}, schema.FTInteger},
+						{schema.FieldName{Name: "field4"}, schema.FTByteString},
+					},
+					KeyFields: schema.PrimaryKey{Fields: []schema.FieldName{{Name: "field1"}, {Name: "field2"}}},
+				}
+			},
+			rows: [][]interface{}{
+				[]interface{}{"hello", "there", 123, []byte{1, 2, 3}},
+			},
+			want: `INSERT INTO family1___table1 ("field1","field2","field3","field4") ` +
+				`VALUES('hello','there',123,x'010203')`,
+		},
+		{
+			name: "basic test with multiple rows",
+			meta: func() MetaTable {
+				famName, _ := schema.NewFamilyName("family1")
+				tblName, _ := schema.NewTableName("table1")
+				return MetaTable{
+					FamilyName: famName,
+					TableName:  tblName,
+					Fields: []schema.NamedFieldType{
+						{schema.FieldName{Name: "field1"}, schema.FTString},
+						{schema.FieldName{Name: "field2"}, schema.FTString},
+						{schema.FieldName{Name: "field3"}, schema.FTInteger},
+						{schema.FieldName{Name: "field4"}, schema.FTByteString},
+					},
+					KeyFields: schema.PrimaryKey{Fields: []schema.FieldName{{Name: "field1"}, {Name: "field2"}}},
+				}
+			},
+			rows: [][]interface{}{
+				[]interface{}{"hello", "there", 123, []byte{4, 5, 6}},
+				[]interface{}{"how", "are'ya", 789, []byte{0, 1, 2}},
+			},
+			want: `INSERT INTO family1___table1 ("field1","field2","field3","field4") ` +
+				`VALUES('hello','there',123,x'040506'),('how','are''ya',789,x'000102')`,
+		},
+		{
+			name: "upsert with null in key column",
+			meta: func() MetaTable {
+				famName, _ := schema.NewFamilyName("family1")
+				tblName, _ := schema.NewTableName("table1")
+				return MetaTable{
+					FamilyName: famName,
+					TableName:  tblName,
+					Fields: []schema.NamedFieldType{
+						{schema.FieldName{Name: "field1"}, schema.FTString},
+						{schema.FieldName{Name: "field2"}, schema.FTString},
+						{schema.FieldName{Name: "field3"}, schema.FTInteger},
+					},
+					KeyFields: schema.PrimaryKey{Fields: []schema.FieldName{{Name: "field1"}, {Name: "field2"}}},
+				}
+			},
+			rows: [][]interface{}{
+				[]interface{}{"a\x00b", "there", 123},
+			},
+			want: `INSERT INTO family1___table1 ("field1","field2","field3") ` +
+				`VALUES(x'610062','there',123)`,
+		},
+		{
+			name: "upsert with null in non-key column",
+			meta: func() MetaTable {
+				famName, _ := schema.NewFamilyName("family1")
+				tblName, _ := schema.NewTableName("table1")
+				return MetaTable{
+					FamilyName: famName,
+					TableName:  tblName,
+					Fields: []schema.NamedFieldType{
+						{schema.FieldName{Name: "field1"}, schema.FTString},
+						{schema.FieldName{Name: "field2"}, schema.FTString},
+						{schema.FieldName{Name: "field3"}, schema.FTInteger},
+					},
+					KeyFields: schema.PrimaryKey{Fields: []schema.FieldName{{Name: "field1"}, {Name: "field2"}}},
+				}
+			},
+			rows: [][]interface{}{
+				[]interface{}{"hi", "a\x00b", 123},
+			},
+			want: `INSERT INTO family1___table1 ("field1","field2","field3") ` +
+				`VALUES('hi',x'610062',123)`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tbl := test.meta()
+			got, err := tbl.BatchInsertDML(test.rows)
+			require.NoError(t, err)
+			require.EqualValues(t, test.want, got)
+		})
+	}
+}
+
 func TestMetaTableDeleteDML(t *testing.T) {
 	for _, test := range []struct {
 		name string


### PR DESCRIPTION
When building custom LDBs (for [`LDBVersioning`](https://github.com/segmentio/ctlstore/pull/34)), we don't use the existing dbz-based streaming writes workflow and instead filter down the contents of the materialized ctlstore tables from the ctldb to just the set of rows we need in each custom LDB.

However, when using the existing `UpsertDML` statement, we have to perform one cgo call per row we are copying into an LDB which is fairly inefficient for any decently sized table.

This PR adds a new function to the `sqlgen` package called `BatchInsertDML` that is based on the existing `UpsertDML` logic except that it performs an `INSERT INTO ... VALUES (...), (...), ...` s.t. it can insert multiple rows in a single cgo sqlite call.