### PR TITLE
Update Snyk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,9 @@ jobs:
       - run:
           name: Snyk Setup
           command: curl -sL https://raw.githubusercontent.com/segmentio/snyk_helpers/master/initialization/snyk.sh | sh
+          environment:
+            SNYK_FAIL_ON: upgradable
+            SNYK_SEVERITY_THRESHOLD: high
       - run:
           name: Build
           command: |


### PR DESCRIPTION
This PR adds Snyk and configures to fail CI on upgradable highs. This is part of an ongoing effort by SecEng to reduce vulnerabilities in our critical repos.

If everything looks good, feel free to merge on my behalf.