### PR TITLE
Add drop-table route to executive HTTP API

### DIFF
--- a/pkg/cmd/ctlstore/main.go
+++ b/pkg/cmd/ctlstore/main.go
@@ -75,6 +75,7 @@ type executiveCliConfig struct {
 	Shadow            bool            `conf:"shadow" help:"set this to true to emit shadow=true metric tags"`
 	Dogstatsd         dogstatsdConfig `conf:"dogstatsd" help:"dogstatsd Configuration"`
 	EnableClearTables bool            `conf:"enable-clear-tables" help:"Turns on the ability to use the clear table executive endpoint which deletes all rows from a table"`
+	EnableDropTables  bool            `conf:"enable-drop-tables" help:"Turns on the ability to use the drop table executive endpoint which drops a table"`
 }
 
 // supervisorCliConfig also composes a reflectorCliConfig because it ends up
@@ -391,6 +392,7 @@ func executive(ctx context.Context, args []string) {
 		WarnTableSize:     50 * units.MEGABYTE,
 		MaxTableSize:      100 * units.MEGABYTE,
 		EnableClearTables: false,
+		EnableDropTables:  false,
 	}
 
 	loadConfig(&cliCfg, "executive", args)
@@ -421,6 +423,7 @@ func executive(ctx context.Context, args []string) {
 		WriterLimit:       cliCfg.WriterLimit,
 		WriterLimitPeriod: cliCfg.WriterLimitPeriod,
 		EnableClearTables: cliCfg.EnableClearTables,
+		EnableDropTables:  cliCfg.EnableDropTables,
 	})
 	if err != nil {
 		errs.IncrDefault(stats.T("op", "startup"))

--- a/pkg/executive/executive.go
+++ b/pkg/executive/executive.go
@@ -39,6 +39,7 @@ type ExecutiveInterface interface {
 	DeleteWriterRateLimit(writerName string) error
 
 	ClearTable(table schema.FamilyTable) error
+	DropTable(table schema.FamilyTable) error
 	ReadFamilyTableNames(familyName schema.FamilyName) ([]schema.FamilyTable, error)
 }
 

--- a/pkg/executive/executive_endpoint.go
+++ b/pkg/executive/executive_endpoint.go
@@ -300,7 +300,7 @@ func (ee *ExecutiveEndpoint) Handler() http.Handler {
 
 	r.HandleFunc("/clear-rows/families/{familyName}", ee.handleClearFamilyRows).Methods("DELETE")
 	r.HandleFunc("/clear-rows/families/{familyName}/tables/{tableName}", ee.handleClearTableRows).Methods("DELETE")
-	r.HandleFunc("/drop-table/families/{familyName}/tables/{tableName}", ee.handleDropTable).Methods("DELETE")
+	r.HandleFunc("/families/{familyName}/tables/{tableName}", ee.handleDropTable).Methods("DELETE")
 
 	// Limit request body sizes
 	r.Use(func(next http.Handler) http.Handler {

--- a/pkg/executive/executive_endpoint.go
+++ b/pkg/executive/executive_endpoint.go
@@ -22,6 +22,7 @@ type ExecutiveEndpoint struct {
 	HealthChecker     HealthChecker
 	Exec              ExecutiveInterface
 	EnableClearTables bool
+	EnableDropTables  bool
 }
 
 func (ee *ExecutiveEndpoint) handleFamilyRoute(w http.ResponseWriter, r *http.Request) {

--- a/pkg/executive/executive_endpoint.go
+++ b/pkg/executive/executive_endpoint.go
@@ -19,10 +19,9 @@ import (
 
 // ExecutiveEndpoint is an HTTP 'wrapper' for ExecutiveInterface
 type ExecutiveEndpoint struct {
-	HealthChecker     HealthChecker
-	Exec              ExecutiveInterface
-	EnableClearTables bool
-	EnableDropTables  bool
+	HealthChecker                  HealthChecker
+	Exec                           ExecutiveInterface
+	EnableDestructiveSchemaChanges bool
 }
 
 func (ee *ExecutiveEndpoint) handleFamilyRoute(w http.ResponseWriter, r *http.Request) {
@@ -413,7 +412,7 @@ func handlingErrorDo(w http.ResponseWriter, fn func() error) {
 }
 
 func (ee *ExecutiveEndpoint) handleDropTable(w http.ResponseWriter, r *http.Request) {
-	if !ee.EnableDropTables {
+	if !ee.EnableDestructiveSchemaChanges {
 		writeErrorResponse(&errs.BadRequestError{Err: "Dropping tables is not enabled."}, w)
 		return
 	}
@@ -439,7 +438,7 @@ func (ee *ExecutiveEndpoint) handleDropTable(w http.ResponseWriter, r *http.Requ
 }
 
 func (ee *ExecutiveEndpoint) handleClearTableRows(w http.ResponseWriter, r *http.Request) {
-	if !ee.EnableClearTables {
+	if !ee.EnableDestructiveSchemaChanges {
 		writeErrorResponse(&errs.BadRequestError{Err: "Clearing tables is not enabled."}, w)
 		return
 	}
@@ -465,7 +464,7 @@ func (ee *ExecutiveEndpoint) handleClearTableRows(w http.ResponseWriter, r *http
 }
 
 func (ee *ExecutiveEndpoint) handleClearFamilyRows(w http.ResponseWriter, r *http.Request) {
-	if !ee.EnableClearTables {
+	if !ee.EnableDestructiveSchemaChanges {
 		writeErrorResponse(&errs.BadRequestError{Err: "Clearing tables is not enabled."}, w)
 		return
 	}

--- a/pkg/executive/executive_endpoint_test.go
+++ b/pkg/executive/executive_endpoint_test.go
@@ -764,7 +764,7 @@ func TestExecEndpointHandler(_t *testing.T) {
 			Method:             http.MethodDelete,
 			ExpectedStatusCode: http.StatusBadRequest,
 			PreFunc: func(t *testing.T, atom *testExecEndpointHandlerAtom) {
-				atom.ee.EnableClearTables = false
+				atom.ee.EnableDestructiveSchemaChanges = false
 			},
 			PostFunc: func(t *testing.T, atom *testExecEndpointHandlerAtom) {
 				require.EqualValues(t, 0, atom.ei.ClearTableCallCount())
@@ -841,7 +841,7 @@ func TestExecEndpointHandler(_t *testing.T) {
 			Method:             http.MethodDelete,
 			ExpectedStatusCode: http.StatusBadRequest,
 			PreFunc: func(t *testing.T, atom *testExecEndpointHandlerAtom) {
-				atom.ee.EnableClearTables = false
+				atom.ee.EnableDestructiveSchemaChanges = false
 			},
 			PostFunc: func(t *testing.T, atom *testExecEndpointHandlerAtom) {
 				require.EqualValues(t, 0, atom.ei.ReadFamilyTableNamesCallCount())
@@ -923,7 +923,7 @@ func TestExecEndpointHandler(_t *testing.T) {
 			}
 
 			a.ei = new(fakes.FakeExecutiveInterface)
-			a.ee = &executive.ExecutiveEndpoint{Exec: a.ei, EnableClearTables: true, EnableDropTables: true}
+			a.ee = &executive.ExecutiveEndpoint{Exec: a.ei, EnableDestructiveSchemaChanges: true}
 			a.rr = httptest.NewRecorder()
 
 			if a.PreFunc != nil {

--- a/pkg/executive/executive_endpoint_test.go
+++ b/pkg/executive/executive_endpoint_test.go
@@ -853,7 +853,7 @@ func TestExecEndpointHandler(_t *testing.T) {
 		},
 		{
 			Desc:               "Drop Table Success",
-			Path:               "/drop-table/families/myfamily/tables/mytable",
+			Path:               "/families/myfamily/tables/mytable",
 			Method:             http.MethodDelete,
 			ExpectedStatusCode: http.StatusOK,
 			PreFunc: func(t *testing.T, atom *testExecEndpointHandlerAtom) {
@@ -870,7 +870,7 @@ func TestExecEndpointHandler(_t *testing.T) {
 		},
 		{
 			Desc:               "Drop Table Failure",
-			Path:               "/drop-table/families/myfamily/tables/mytable",
+			Path:               "/families/myfamily/tables/mytable",
 			Method:             http.MethodDelete,
 			ExpectedStatusCode: http.StatusInternalServerError,
 			PreFunc: func(t *testing.T, atom *testExecEndpointHandlerAtom) {

--- a/pkg/executive/fakes/executive_interface.go
+++ b/pkg/executive/fakes/executive_interface.go
@@ -2,11 +2,11 @@
 package fakes
 
 import (
-	sync "sync"
+	"sync"
 
-	executive "github.com/segmentio/ctlstore/pkg/executive"
-	limits "github.com/segmentio/ctlstore/pkg/limits"
-	schema "github.com/segmentio/ctlstore/pkg/schema"
+	"github.com/segmentio/ctlstore/pkg/executive"
+	"github.com/segmentio/ctlstore/pkg/limits"
+	"github.com/segmentio/ctlstore/pkg/schema"
 )
 
 type FakeExecutiveInterface struct {
@@ -81,6 +81,17 @@ type FakeExecutiveInterface struct {
 		result1 error
 	}
 	deleteWriterRateLimitReturnsOnCall map[int]struct {
+		result1 error
+	}
+	DropTableStub        func(schema.FamilyTable) error
+	dropTableMutex       sync.RWMutex
+	dropTableArgsForCall []struct {
+		arg1 schema.FamilyTable
+	}
+	dropTableReturns struct {
+		result1 error
+	}
+	dropTableReturnsOnCall map[int]struct {
 		result1 error
 	}
 	GetWriterCookieStub        func(string, string) ([]byte, error)
@@ -604,6 +615,66 @@ func (fake *FakeExecutiveInterface) DeleteWriterRateLimitReturnsOnCall(i int, re
 		})
 	}
 	fake.deleteWriterRateLimitReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeExecutiveInterface) DropTable(arg1 schema.FamilyTable) error {
+	fake.dropTableMutex.Lock()
+	ret, specificReturn := fake.dropTableReturnsOnCall[len(fake.dropTableArgsForCall)]
+	fake.dropTableArgsForCall = append(fake.dropTableArgsForCall, struct {
+		arg1 schema.FamilyTable
+	}{arg1})
+	fake.recordInvocation("DropTable", []interface{}{arg1})
+	fake.dropTableMutex.Unlock()
+	if fake.DropTableStub != nil {
+		return fake.DropTableStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.dropTableReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeExecutiveInterface) DropTableCallCount() int {
+	fake.dropTableMutex.RLock()
+	defer fake.dropTableMutex.RUnlock()
+	return len(fake.dropTableArgsForCall)
+}
+
+func (fake *FakeExecutiveInterface) DropTableCalls(stub func(schema.FamilyTable) error) {
+	fake.dropTableMutex.Lock()
+	defer fake.dropTableMutex.Unlock()
+	fake.DropTableStub = stub
+}
+
+func (fake *FakeExecutiveInterface) DropTableArgsForCall(i int) schema.FamilyTable {
+	fake.dropTableMutex.RLock()
+	defer fake.dropTableMutex.RUnlock()
+	argsForCall := fake.dropTableArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeExecutiveInterface) DropTableReturns(result1 error) {
+	fake.dropTableMutex.Lock()
+	defer fake.dropTableMutex.Unlock()
+	fake.DropTableStub = nil
+	fake.dropTableReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeExecutiveInterface) DropTableReturnsOnCall(i int, result1 error) {
+	fake.dropTableMutex.Lock()
+	defer fake.dropTableMutex.Unlock()
+	fake.DropTableStub = nil
+	if fake.dropTableReturnsOnCall == nil {
+		fake.dropTableReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.dropTableReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -1253,6 +1324,8 @@ func (fake *FakeExecutiveInterface) Invocations() map[string][][]interface{} {
 	defer fake.deleteTableSizeLimitMutex.RUnlock()
 	fake.deleteWriterRateLimitMutex.RLock()
 	defer fake.deleteWriterRateLimitMutex.RUnlock()
+	fake.dropTableMutex.RLock()
+	defer fake.dropTableMutex.RUnlock()
 	fake.getWriterCookieMutex.RLock()
 	defer fake.getWriterCookieMutex.RUnlock()
 	fake.mutateMutex.RLock()

--- a/pkg/sqlgen/sqlgen.go
+++ b/pkg/sqlgen/sqlgen.go
@@ -265,6 +265,14 @@ func (t *MetaTable) DeleteDML(values []interface{}) (string, error) {
 	return buf.String(), nil
 }
 
+func (t *MetaTable) DropTableDDL() string {
+	tableName := schema.LDBTableName(t.FamilyName, t.TableName)
+	ddl := SqlSprintf(
+		"DROP TABLE IF EXISTS $1",
+		tableName)
+	return ddl
+}
+
 func (t *MetaTable) ClearTableDDL() string {
 	tableName := schema.LDBTableName(t.FamilyName, t.TableName)
 	ddl := SqlSprintf(

--- a/pkg/sqlgen/sqlgen_test.go
+++ b/pkg/sqlgen/sqlgen_test.go
@@ -327,6 +327,22 @@ func TestMetaTableClearTableDDL(t *testing.T) {
 	}
 }
 
+func TestMetaTableDropTableDDL(t *testing.T) {
+	famName, _ := schema.NewFamilyName("family1")
+	tblName, _ := schema.NewTableName("table1")
+	tbl := MetaTable{
+		FamilyName: famName,
+		TableName:  tblName,
+		Fields: []schema.NamedFieldType{
+			{schema.FieldName{Name: "field1"}, schema.FTString},
+		},
+		KeyFields: schema.PrimaryKey{Fields: []schema.FieldName{{Name: "field1"}}},
+	}
+
+	got := tbl.DropTableDDL()
+	require.EqualValues(t, `DROP TABLE IF EXISTS family1___table1`, got)
+}
+
 func TestSQLQuote(t *testing.T) {
 	suite := []struct {
 		desc   string


### PR DESCRIPTION
This will only be enabled for the stage environment.  It allows folks to drop a table they didn't meant to create, or perhaps created incorrectly.  This prevents the user from needing to create a second table.

FOR THE ROBOT THAT ALWAYS WATCHES:

Testing completed successfully in stage.