### PR TITLE
Do not use module versions for ctlstore binary

### DIFF
--- a/pkg/version/version_go1_12.go
+++ b/pkg/version/version_go1_12.go
@@ -17,14 +17,10 @@ const path = "github.com/segmentio/ctlstore"
 // with the build tag above.
 func init() {
 	if info, ok := debug.ReadBuildInfo(); ok && info != nil {
-		if info.Main.Path == path {
-			version = info.Main.Version
-		} else {
-			for _, mod := range info.Deps {
-				if mod != nil {
-					if mod.Path == path {
-						version = mod.Version
-					}
+		for _, mod := range info.Deps {
+			if mod != nil {
+				if mod.Path == path {
+					version = mod.Version
 				}
 			}
 		}


### PR DESCRIPTION
This changes the code that reports the ctlstore version.
We added support for determining the ctlstore version
from the go modules metadata.

We compare the module path `github.com/segmentio/ctlstore`
to each module's metadata and if it matches we report that
as the version.

The issue is that for ctlstore itself (reflector, executive, etc)
the main module path will always match, and will always report
`(devel)` as the module version.

What we really want to do is only to check the dependency module
list for the ctlstore module, as this is really meant for client
programs that use ctlstore, so that the stats will report the
module version.

This removes the code that checks the main module path. In this
case, the version that was already set in the CI build will now
report properly.