### PR TITLE
Avoid logging DB password on sql.Open error

### DIFF
--- a/pkg/reflector/reflector.go
+++ b/pkg/reflector/reflector.go
@@ -141,7 +141,7 @@ func ReflectorFromConfig(config ReflectorConfig) (*Reflector, error) {
 
 	upstreamdb, err := sql.Open(config.Upstream.Driver, dsn)
 	if err != nil {
-		return nil, fmt.Errorf("Error when opening upstream DB (%v) '%v': %v", config.Upstream.Driver, config.Upstream.DSN, err)
+		return nil, fmt.Errorf("Error when opening upstream DB (%v): %v", config.Upstream.Driver, err)
 	}
 
 	row := upstreamdb.QueryRow("select max(seq) from " + config.Upstream.LedgerTable)


### PR DESCRIPTION
We could try to redact the password from the DSN (similar to [`segmentio/sensitive`](https://github.com/segmentio/sensitive/blob/master/mysql_dsn.go)). But just removing the DSN from the log seems good enough.