### PR TITLE
Use the tx to modify the ctldb.

### DIFF
--- a/pkg/executive/db_executive.go
+++ b/pkg/executive/db_executive.go
@@ -203,7 +203,7 @@ func (e *dbExecutive) AddFields(familyName string, tableName string, fieldNames 
 				TableName: dmlLedgerTableName,
 			}
 			defer dlw.Close()
-			_, err = e.DB.ExecContext(ctx, ddl)
+			_, err = tx.ExecContext(ctx, ddl)
 			if err != nil {
 				if strings.Index(err.Error(), "Error 1060:") == 0 || // mysql
 					strings.Contains(err.Error(), "duplicate column name") { // sqlite

--- a/pkg/executive/db_executive.go
+++ b/pkg/executive/db_executive.go
@@ -124,7 +124,7 @@ func (e *dbExecutive) CreateTable(familyName string, tableName string, fieldName
 	}
 	defer dlw.Close()
 
-	_, err = e.DB.ExecContext(ctx, ddl)
+	_, err = tx.ExecContext(ctx, ddl)
 	if err != nil {
 		if strings.Index(err.Error(), "Error 1050:") == 0 ||
 			strings.Contains(err.Error(), "already exists") {
@@ -922,7 +922,7 @@ func (e *dbExecutive) DropTable(table schema.FamilyTable) error {
 	}
 	defer dlw.Close()
 
-	_, err = e.DB.ExecContext(ctx, ddl)
+	_, err = tx.ExecContext(ctx, ddl)
 	if err != nil {
 		return errors.Wrap(err, "error running drop command")
 	}
@@ -989,7 +989,7 @@ func (e *dbExecutive) ClearTable(table schema.FamilyTable) error {
 	}
 	defer dlw.Close()
 
-	_, err = e.DB.ExecContext(ctx, ddl)
+	_, err = tx.ExecContext(ctx, ddl)
 	if err != nil {
 		return errors.Wrap(err, "error running delete command")
 	}

--- a/pkg/executive/dml_ledger_writer_test.go
+++ b/pkg/executive/dml_ledger_writer_test.go
@@ -50,7 +50,7 @@ func TestDMLLogWriterAdd(t *testing.T) {
 				seqs = append(seqs, seq)
 			}
 
-			row := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM ctlstore_dml_ledger")
+			row := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM ctlstore_dml_ledger")
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}

--- a/pkg/executive/dml_ledger_writer_test.go
+++ b/pkg/executive/dml_ledger_writer_test.go
@@ -50,7 +50,7 @@ func TestDMLLogWriterAdd(t *testing.T) {
 				seqs = append(seqs, seq)
 			}
 
-			row := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM ctlstore_dml_ledger")
+			row := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM ctlstore_dml_ledger")
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}

--- a/pkg/sqlgen/sqlgen.go
+++ b/pkg/sqlgen/sqlgen.go
@@ -487,7 +487,7 @@ func SqlSprintf(format string, args ...string) string {
 
 		whichArg := int(parsed) - 1
 		if whichArg > len(args) {
-			panic("Placeholder $" + string(whichArg) + " exceeds argument count")
+			panic("Placeholder $" + strconv.Itoa(whichArg) + " exceeds argument count")
 		}
 		if !sqlPrintfValidValue.MatchString(args[whichArg]) {
 			panic("Invalid value: " + args[whichArg])


### PR DESCRIPTION
We ran into a bug when trying to add columns to an existing
table. The update applied to the ctldb but a ledger entry
was never added. This caused downstream issues as the
LDBs never got the column added.

The cause is that the ctldb change was not using the transaction
handle previously created. This fixes it to use the tx
handle for both the ctldb update and the ledger update.