### PR TITLE
Add option to specify S3 bootstrap region.

### DIFF
--- a/pkg/cmd/ctlstore/main.go
+++ b/pkg/cmd/ctlstore/main.go
@@ -54,6 +54,7 @@ type reflectorCliConfig struct {
 	UpstreamDSN           string             `conf:"upstream-dsn" help:"Upstream DSN (e.g. path to file if sqlite3)" validate:"nonzero"`
 	UpstreamLedgerTable   string             `conf:"upstream-ledger-table" help:"Table on the upstream to look for statement ledger"`
 	BootstrapURL          string             `conf:"bootstrap-url" help:"Bootstraps LDB from an S3 URL"`
+	BootstrapRegion       string             `conf:"boostrap-region" help:"If specified, indicates which region in which the S3 bucket lives"`
 	PollInterval          time.Duration      `conf:"poll-interval" help:"How often to pull the upstream" validate:"nonzero"`
 	PollJitterCoefficient float64            `conf:"poll-jitter-coefficient" help:"Coefficient for poll jittering"`
 	QueryBlockSize        int                `conf:"query-block-size" help:"Number of ledger entries to get at once"`
@@ -552,11 +553,12 @@ func newReflector(cliCfg reflectorCliConfig, isSupervisor bool) (*reflectorpkg.R
 		events.Log("DEPRECATION NOTICE: use --disable-ecs-behavior instead of --disable to control this ledger monitor behavior")
 	}
 	return reflectorpkg.ReflectorFromConfig(reflectorpkg.ReflectorConfig{
-		LDBPath:       cliCfg.LDBPath,
-		ChangelogPath: cliCfg.ChangelogPath,
-		ChangelogSize: cliCfg.ChangelogSize,
-		BootstrapURL:  cliCfg.BootstrapURL,
-		IsSupervisor:  isSupervisor,
+		LDBPath:         cliCfg.LDBPath,
+		ChangelogPath:   cliCfg.ChangelogPath,
+		ChangelogSize:   cliCfg.ChangelogSize,
+		BootstrapURL:    cliCfg.BootstrapURL,
+		BootstrapRegion: cliCfg.BootstrapRegion,
+		IsSupervisor:    isSupervisor,
 		LedgerHealth: ledger.HealthConfig{
 			DisableECSBehavior:      cliCfg.LedgerHealth.Disable || cliCfg.LedgerHealth.DisableECSBehavior,
 			MaxHealthyLatency:       cliCfg.LedgerHealth.MaxHealthyLatency,

--- a/pkg/cmd/ctlstore/main.go
+++ b/pkg/cmd/ctlstore/main.go
@@ -54,7 +54,7 @@ type reflectorCliConfig struct {
 	UpstreamDSN           string             `conf:"upstream-dsn" help:"Upstream DSN (e.g. path to file if sqlite3)" validate:"nonzero"`
 	UpstreamLedgerTable   string             `conf:"upstream-ledger-table" help:"Table on the upstream to look for statement ledger"`
 	BootstrapURL          string             `conf:"bootstrap-url" help:"Bootstraps LDB from an S3 URL"`
-	BootstrapRegion       string             `conf:"boostrap-region" help:"If specified, indicates which region in which the S3 bucket lives"`
+	BootstrapRegion       string             `conf:"bootstrap-region" help:"If specified, indicates which region in which the S3 bucket lives"`
 	PollInterval          time.Duration      `conf:"poll-interval" help:"How often to pull the upstream" validate:"nonzero"`
 	PollJitterCoefficient float64            `conf:"poll-jitter-coefficient" help:"Coefficient for poll jittering"`
 	QueryBlockSize        int                `conf:"query-block-size" help:"Number of ledger entries to get at once"`

--- a/pkg/reflector/download.go
+++ b/pkg/reflector/download.go
@@ -21,6 +21,7 @@ type downloadTo interface {
 }
 
 type S3Downloader struct {
+	Region              string // optional
 	Bucket              string
 	Key                 string
 	S3Client            S3Client
@@ -70,7 +71,13 @@ func (d *S3Downloader) getS3Client() (S3Client, error) {
 	if d.S3Client != nil {
 		return d.S3Client, nil
 	}
-	sess := session.Must(session.NewSession())
+	configs := []*aws.Config{}
+	if d.Region != "" {
+		configs = append(configs, &aws.Config{
+			Region: aws.String(d.Region),
+		})
+	}
+	sess := session.Must(session.NewSession(configs...))
 	client := s3.New(sess)
 	return client, nil
 }


### PR DESCRIPTION
When the reflector bootstraps, this change will allow it to
try and pull the snapshot from a region different than the
one in which it currently resides. The default behavior is
left unchanged.

This change is required for multi-region data residency requirements.

Testing completed successfully in stage in both the normal AWS
region as well as a new region that requires cross-region access. 
Both reflectors were able to bootstrap the LDB from the regional
bucket.