### PR TITLE
Apply DML first, and then DDL

### DIFF
--- a/pkg/cmd/ctlstore/main.go
+++ b/pkg/cmd/ctlstore/main.go
@@ -385,7 +385,7 @@ func executive(ctx context.Context, args []string) {
 	cliCfg := executiveCliConfig{
 		Bind:                           "",
 		CtlDBDSN:                       "",
-		HandlerTimeout:                 5 * time.Second,
+		HandlerTimeout:                 30 * time.Second,
 		Dogstatsd:                      defaultDogstatsdConfig(),
 		WriterLimitPeriod:              time.Minute,
 		WriterLimit:                    1000,

--- a/pkg/executive/db_executive.go
+++ b/pkg/executive/db_executive.go
@@ -126,7 +126,7 @@ func (e *dbExecutive) CreateTable(familyName string, tableName string, fieldName
 
 	seq, err := dlw.Add(ctx, logDDL)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "apply dml")
 	}
 
 	_, err = tx.ExecContext(ctx, ddl)
@@ -135,7 +135,7 @@ func (e *dbExecutive) CreateTable(familyName string, tableName string, fieldName
 			strings.Contains(err.Error(), "already exists") {
 			return &errs.ConflictError{Err: "Table already exists"}
 		}
-		return err
+		return errors.Wrap(err, "apply ddl")
 	}
 
 	err = tx.Commit()

--- a/pkg/executive/db_executive.go
+++ b/pkg/executive/db_executive.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/pkg/errors"
 	"github.com/segmentio/ctlstore/pkg/errs"
 	"github.com/segmentio/ctlstore/pkg/ldb"
@@ -15,6 +16,7 @@ import (
 	"github.com/segmentio/ctlstore/pkg/schema"
 	"github.com/segmentio/ctlstore/pkg/sqlgen"
 	"github.com/segmentio/events/v2"
+	"github.com/segmentio/go-sqlite3"
 )
 
 const dmlLedgerTableName = "ctlstore_dml_ledger"
@@ -129,7 +131,7 @@ func (e *dbExecutive) CreateTable(familyName string, tableName string, fieldName
 		return errors.Wrap(err, "apply dml")
 	}
 
-	_, err = tx.ExecContext(ctx, ddl)
+	_, err = e.applyDDL(ctx, tx, ddl)
 	if err != nil {
 		if strings.Index(err.Error(), "Error 1050:") == 0 ||
 			strings.Contains(err.Error(), "already exists") {
@@ -146,6 +148,26 @@ func (e *dbExecutive) CreateTable(familyName string, tableName string, fieldName
 	events.Log("Successfully created new table `%{tableName}s` at seq %{seq}v", tableName, seq)
 
 	return nil
+}
+
+// applyDDL executes the DDL in the tx if the backing store is sqlite, and outside of the
+// tx if the backing store is mysql. The reason for this is that sqlite treats ddl transactionally,
+// while mysql does not. When DDL is executed as part of an ongoing tx, mysql implicitly commits
+// the transaction, preventing the ability to roll back any statements previously applied as
+// part of the transaction.
+func (e *dbExecutive) applyDDL(ctx context.Context, tx *sql.Tx, ddl string) (sql.Result, error) {
+	switch e.DB.Driver().(type) {
+	case *mysql.MySQLDriver:
+		// mysql does not support transactional ddl, so we must execute this
+		// statement outside of the current tx to prevent it from being implicitly
+		// committed by the ddl
+		return e.DB.ExecContext(ctx, ddl)
+	case *sqlite3.SQLiteDriver:
+		// sqlite supports transactional ddl
+		return tx.ExecContext(ctx, ddl)
+	default:
+		return nil, errors.Errorf("Unknown driver: %T", e.DB.Driver())
+	}
 }
 
 func (e *dbExecutive) AddFields(familyName string, tableName string, fieldNames []string, fieldTypes []schema.FieldType) error {
@@ -212,7 +234,7 @@ func (e *dbExecutive) AddFields(familyName string, tableName string, fieldNames 
 
 			// Next, apply the DDL to the ctldb. If the DDL fails, return the err, which will
 			// roll back the transaction under which the DML was written to the ledger.
-			_, err = tx.ExecContext(ctx, ddl)
+			_, err = e.applyDDL(ctx, tx, ddl)
 			if err != nil {
 				if strings.Index(err.Error(), "Error 1060:") == 0 || // mysql
 					strings.Contains(err.Error(), "duplicate column name") { // sqlite
@@ -221,7 +243,7 @@ func (e *dbExecutive) AddFields(familyName string, tableName string, fieldNames 
 				return errors.Wrap(err, "apply ddl")
 			}
 
-			// the DDL implicitly commits the transaction, but we go ahead and commit here anyways.
+			// if the DDL succeeds, commit the transaction
 			err = tx.Commit()
 			if err != nil {
 				return errors.Wrap(err, "commit tx")

--- a/pkg/executive/db_executive.go
+++ b/pkg/executive/db_executive.go
@@ -124,17 +124,17 @@ func (e *dbExecutive) CreateTable(familyName string, tableName string, fieldName
 	}
 	defer dlw.Close()
 
+	seq, err := dlw.Add(ctx, logDDL)
+	if err != nil {
+		return err
+	}
+
 	_, err = tx.ExecContext(ctx, ddl)
 	if err != nil {
 		if strings.Index(err.Error(), "Error 1050:") == 0 ||
 			strings.Contains(err.Error(), "already exists") {
 			return &errs.ConflictError{Err: "Table already exists"}
 		}
-		return err
-	}
-
-	seq, err := dlw.Add(ctx, logDDL)
-	if err != nil {
 		return err
 	}
 

--- a/pkg/executive/db_executive_test.go
+++ b/pkg/executive/db_executive_test.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -292,11 +293,44 @@ func testDBExecutiveRegisterWriter(t *testing.T, dbType string) {
 	require.Equal(t, err, ErrWriterAlreadyExists)
 }
 
+func queryDMLTable(t *testing.T, db *sql.DB, limit int) []string {
+	sql := "select statement from ctlstore_dml_ledger order by seq desc"
+	if limit > 0 {
+		sql += " limit " + strconv.Itoa(limit)
+	}
+	stRows, err := db.Query("select statement from ctlstore_dml_ledger order by seq desc limit 6")
+	require.NoError(t, err)
+	var statements []string
+	for stRows.Next() {
+		var statement string
+		err := stRows.Scan(&statement)
+		require.NoError(t, err)
+		statements = append(statements, statement)
+	}
+	require.NoError(t, stRows.Err())
+	return statements
+}
+
 func testDBExecutiveAddFields(t *testing.T, dbType string) {
 	u := newDbExecTestUtil(t, dbType)
 	defer u.Close()
 
-	err := u.e.CreateTable("family1",
+	addFields := func() error {
+		return u.e.AddFields("family1",
+			"table2",
+			[]string{"field7", "field8", "field9", "field10", "field11", "field12"},
+			[]schema.FieldType{schema.FTString, schema.FTInteger, schema.FTByteString, schema.FTDecimal, schema.FTText, schema.FTBinary},
+		)
+	}
+
+	// first verify that we cannot add to the table if it does not already exist.
+	err := addFields()
+	require.Error(t, err)
+	// also verify that no DML exists
+	dmls := queryDMLTable(t, u.db, -1)
+	require.Empty(t, dmls)
+
+	err = u.e.CreateTable("family1",
 		"table2",
 		[]string{"field1", "field2", "field3", "field4", "field5", "field6"},
 		[]schema.FieldType{schema.FTString, schema.FTInteger, schema.FTByteString, schema.FTDecimal, schema.FTText, schema.FTBinary},
@@ -306,11 +340,7 @@ func testDBExecutiveAddFields(t *testing.T, dbType string) {
 		t.Fatalf("Unexpected error calling CreateTable: %+v", err)
 	}
 
-	err = u.e.AddFields("family1",
-		"table2",
-		[]string{"field7", "field8", "field9", "field10", "field11", "field12"},
-		[]schema.FieldType{schema.FTString, schema.FTInteger, schema.FTByteString, schema.FTDecimal, schema.FTText, schema.FTBinary},
-	)
+	err = addFields()
 	if err != nil {
 		t.Fatalf("Unexpected error calling UpdateTable: %+v", err)
 	}
@@ -332,16 +362,7 @@ func testDBExecutiveAddFields(t *testing.T, dbType string) {
 	}
 
 	// ensure that the DML was added to the ledger
-	stRows, err := u.db.Query("select statement from ctlstore_dml_ledger order by seq desc limit 6")
-	require.NoError(t, err)
-	var statements []string
-	for stRows.Next() {
-		var statement string
-		err := stRows.Scan(&statement)
-		require.NoError(t, err)
-		statements = append(statements, statement)
-	}
-	require.NoError(t, stRows.Err())
+	statements := queryDMLTable(t, u.db, 6)
 	require.EqualValues(t, []string{
 		"ALTER TABLE family1___table2 ADD COLUMN \"field12\" BLOB",
 		"ALTER TABLE family1___table2 ADD COLUMN \"field11\" TEXT",
@@ -365,15 +386,24 @@ func testDBExecutiveCreateTable(t *testing.T, dbType string) {
 	u := newDbExecTestUtil(t, dbType)
 	defer u.Close()
 
-	err := u.e.CreateTable("family1",
-		"table2",
-		[]string{"field1", "field2", "field3", "field4", "field5", "field6"},
-		[]schema.FieldType{schema.FTString, schema.FTInteger, schema.FTByteString, schema.FTDecimal, schema.FTText, schema.FTBinary},
-		[]string{"field1", "field2", "field3"},
-	)
-	if err != nil {
-		t.Fatalf("Unexpected error calling CreateTable: %+v", err)
+	createTable := func() error {
+		return u.e.CreateTable("family1",
+			"table2",
+			[]string{"field1", "field2", "field3", "field4", "field5", "field6"},
+			[]schema.FieldType{schema.FTString, schema.FTInteger, schema.FTByteString, schema.FTDecimal, schema.FTText, schema.FTBinary},
+			[]string{"field1", "field2", "field3"},
+		)
 	}
+	err := createTable()
+	require.NoError(t, err)
+	dmls := queryDMLTable(t, u.db, -1)
+	require.Len(t, dmls, 1) // one DML should exist to create the table
+
+	// try to create the table again, verify it fails, and verify that the ledger is correct
+	err = createTable()
+	require.Error(t, err)
+	dmls = queryDMLTable(t, u.db, -1)
+	require.Len(t, dmls, 1) // there should still only be one DML
 
 	// Just check that an empty table exists at all, because the field
 	// creation logic gets checked by sqlgen unit tests


### PR DESCRIPTION
Because applying DDL in mysql auto-commits an ongoing transaction, modifications which need to apply both DDL and DML would leave DDL in place but not DML when the transaction failed in between those steps.

To alleviate this problem we reverse the order, applying the DML and then the DDL.  If the operation fails in between the two, the DML is able to be rolled back.

We also increase the default HTTP handler timeout from 5s -> 30s. This will help prevent timeouts while adding multiple fields in one API call to the executive.

Testing completed successfully in stage via deploying the executive with a 500ms handler timeout, and testing that repeated AddFields operations failed, but left the ledger in a good state.