### PR TITLE
Add ability to render all schemas in a particular family.

### DIFF
--- a/pkg/executive/db_executive.go
+++ b/pkg/executive/db_executive.go
@@ -31,6 +31,29 @@ type dbExecutive struct {
 
 var ErrTableDoesNotExist = errors.New("table does not exist")
 
+func (e *dbExecutive) FamilySchemas(family string) ([]schema.Table, error) {
+	familyName, err := schema.NewFamilyName(family)
+	if err != nil {
+		return nil, errors.Wrap(err, "family name")
+	}
+	dbInfo := getDBInfo(e.DB)
+	tables, err := dbInfo.GetAllTables(context.TODO())
+	if err != nil {
+		return nil, errors.Wrap(err, "get table names")
+	}
+	var res []schema.Table
+	for _, table := range tables {
+		if table.Family == familyName.String() {
+			ts, err := e.TableSchema(familyName.Name, table.Table)
+			if err != nil {
+				return nil, errors.Wrap(err, "get table schema")
+			}
+			res = append(res, *ts)
+		}
+	}
+	return res, nil
+}
+
 func (e *dbExecutive) TableSchema(family, table string) (*schema.Table, error) {
 	familyName, err := schema.NewFamilyName(family)
 	if err != nil {

--- a/pkg/executive/db_info.go
+++ b/pkg/executive/db_info.go
@@ -14,6 +14,7 @@ import (
 
 type sqlDBInfo interface {
 	GetColumnInfo(ctx context.Context, tableNames []string) ([]schema.DBColumnInfo, error)
+	GetAllTables(ctx context.Context) ([]schema.FamilyTable, error)
 }
 
 func getDBInfo(db *sql.DB) sqlDBInfo {

--- a/pkg/executive/executive.go
+++ b/pkg/executive/executive.go
@@ -29,6 +29,7 @@ type ExecutiveInterface interface {
 	RegisterWriter(writerName string, writerSecret string) error
 
 	TableSchema(familyName string, tableName string) (*schema.Table, error)
+	FamilySchemas(familyName string) ([]schema.Table, error)
 
 	ReadRow(familyName string, tableName string, where map[string]interface{}) (map[string]interface{}, error)
 

--- a/pkg/executive/executive_endpoint.go
+++ b/pkg/executive/executive_endpoint.go
@@ -138,6 +138,25 @@ func (ee *ExecutiveEndpoint) handleCookieRoute(w http.ResponseWriter, r *http.Re
 	w.WriteHeader(http.StatusMethodNotAllowed)
 }
 
+func (ee *ExecutiveEndpoint) handleFamilySchemasRoute(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	familyName := vars["familyName"]
+	schemas, err := ee.Exec.FamilySchemas(familyName)
+	switch {
+	case err == nil:
+	default:
+		writeErrorResponse(err, w)
+		return
+	}
+	bs, err := json.Marshal(schemas)
+	if err != nil {
+		writeErrorResponse(err, w)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(bs)
+}
+
 func (ee *ExecutiveEndpoint) handleTableSchemaRoute(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	familyName := vars["familyName"]
@@ -312,6 +331,7 @@ func (ee *ExecutiveEndpoint) Handler() http.Handler {
 	r.HandleFunc("/writers/{writerName}", ee.handleWritersRoute).Methods("POST")
 
 	r.HandleFunc("/schema/table/{familyName}/{tableName}", ee.handleTableSchemaRoute).Methods(http.MethodGet)
+	r.HandleFunc("/schema/family/{familyName}", ee.handleFamilySchemasRoute).Methods(http.MethodGet)
 
 	r.HandleFunc("/limits/tables", ee.handleTableLimitsRead).Methods("GET")
 	r.HandleFunc("/limits/tables/{familyName}/{tableName}", ee.handleTableLimitsUpdate).Methods("POST")

--- a/pkg/executive/executive_endpoint_test.go
+++ b/pkg/executive/executive_endpoint_test.go
@@ -3,12 +3,13 @@ package executive_test
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/pkg/errors"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/segmentio/ctlstore/pkg/errs"
@@ -885,7 +886,6 @@ func TestExecEndpointHandler(_t *testing.T) {
 				}, ft)
 			},
 		},
-
 		{
 			Desc:               "Get Table Schema Success",
 			Path:               "/schema/table/foofamily/bartable",
@@ -895,7 +895,7 @@ func TestExecEndpointHandler(_t *testing.T) {
 				ret := &schema.Table{
 					Family: "foofamily",
 					Name:   "bartable",
-					Fields:    [][]string{
+					Fields: [][]string{
 						{"field1", "string"},
 					},
 					KeyFields: []string{"field1"},
@@ -907,7 +907,7 @@ func TestExecEndpointHandler(_t *testing.T) {
 				ret := &schema.Table{
 					Family: "foofamily",
 					Name:   "bartable",
-					Fields:    [][]string{
+					Fields: [][]string{
 						{"field1", "string"},
 					},
 					KeyFields: []string{"field1"},
@@ -917,7 +917,6 @@ func TestExecEndpointHandler(_t *testing.T) {
 				require.True(t, bytes.Equal(bs, atom.rr.Body.Bytes()))
 			},
 		},
-
 		{
 			Desc:               "Get Table Schema Error",
 			Path:               "/schema/table/foofamily/bartable",
@@ -929,6 +928,60 @@ func TestExecEndpointHandler(_t *testing.T) {
 			PostFunc: func(t *testing.T, atom *testExecEndpointHandlerAtom) {
 				require.EqualValues(t, 1, atom.ei.TableSchemaCallCount())
 				require.Equal(t, "boom: table does not exist\n", atom.rr.Body.String())
+			},
+		},
+		{
+			Desc:               "Get Family Schema Success",
+			Path:               "/schema/family/foofamily",
+			Method:             http.MethodGet,
+			ExpectedStatusCode: http.StatusOK,
+			PreFunc: func(t *testing.T, atom *testExecEndpointHandlerAtom) {
+				ret := []schema.Table{
+					{
+						Family: "foofamily",
+						Name:   "bartable",
+						Fields: [][]string{
+							{"field1", "string"},
+						},
+						KeyFields: []string{"field1"},
+					},
+					{
+						Family: "foofamily",
+						Name:   "bartable2",
+						Fields: [][]string{
+							{"field1", "string"},
+							{"field2", "integer"},
+						},
+						KeyFields: []string{"field1"},
+					},
+				}
+				atom.ei.FamilySchemasReturns(ret, nil)
+			},
+			PostFunc: func(t *testing.T, atom *testExecEndpointHandlerAtom) {
+				require.EqualValues(t, 0, atom.ei.TableSchemaCallCount())
+				require.EqualValues(t, 1, atom.ei.FamilySchemasCallCount())
+				ret := []schema.Table{
+					{
+						Family: "foofamily",
+						Name:   "bartable",
+						Fields: [][]string{
+							{"field1", "string"},
+						},
+						KeyFields: []string{"field1"},
+					},
+					{
+						Family: "foofamily",
+						Name:   "bartable2",
+						Fields: [][]string{
+							{"field1", "string"},
+							{"field2", "integer"},
+						},
+						KeyFields: []string{"field1"},
+					},
+				}
+				bs, err := json.Marshal(ret)
+				require.NoError(t, err)
+				require.EqualValues(t, string(bs), atom.rr.Body.String())
 			},
 		},
 	}

--- a/pkg/executive/fakes/executive_interface.go
+++ b/pkg/executive/fakes/executive_interface.go
@@ -94,6 +94,19 @@ type FakeExecutiveInterface struct {
 	dropTableReturnsOnCall map[int]struct {
 		result1 error
 	}
+	FamilySchemasStub        func(string) ([]schema.Table, error)
+	familySchemasMutex       sync.RWMutex
+	familySchemasArgsForCall []struct {
+		arg1 string
+	}
+	familySchemasReturns struct {
+		result1 []schema.Table
+		result2 error
+	}
+	familySchemasReturnsOnCall map[int]struct {
+		result1 []schema.Table
+		result2 error
+	}
 	GetWriterCookieStub        func(string, string) ([]byte, error)
 	getWriterCookieMutex       sync.RWMutex
 	getWriterCookieArgsForCall []struct {
@@ -691,6 +704,69 @@ func (fake *FakeExecutiveInterface) DropTableReturnsOnCall(i int, result1 error)
 	fake.dropTableReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeExecutiveInterface) FamilySchemas(arg1 string) ([]schema.Table, error) {
+	fake.familySchemasMutex.Lock()
+	ret, specificReturn := fake.familySchemasReturnsOnCall[len(fake.familySchemasArgsForCall)]
+	fake.familySchemasArgsForCall = append(fake.familySchemasArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("FamilySchemas", []interface{}{arg1})
+	fake.familySchemasMutex.Unlock()
+	if fake.FamilySchemasStub != nil {
+		return fake.FamilySchemasStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.familySchemasReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeExecutiveInterface) FamilySchemasCallCount() int {
+	fake.familySchemasMutex.RLock()
+	defer fake.familySchemasMutex.RUnlock()
+	return len(fake.familySchemasArgsForCall)
+}
+
+func (fake *FakeExecutiveInterface) FamilySchemasCalls(stub func(string) ([]schema.Table, error)) {
+	fake.familySchemasMutex.Lock()
+	defer fake.familySchemasMutex.Unlock()
+	fake.FamilySchemasStub = stub
+}
+
+func (fake *FakeExecutiveInterface) FamilySchemasArgsForCall(i int) string {
+	fake.familySchemasMutex.RLock()
+	defer fake.familySchemasMutex.RUnlock()
+	argsForCall := fake.familySchemasArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeExecutiveInterface) FamilySchemasReturns(result1 []schema.Table, result2 error) {
+	fake.familySchemasMutex.Lock()
+	defer fake.familySchemasMutex.Unlock()
+	fake.FamilySchemasStub = nil
+	fake.familySchemasReturns = struct {
+		result1 []schema.Table
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeExecutiveInterface) FamilySchemasReturnsOnCall(i int, result1 []schema.Table, result2 error) {
+	fake.familySchemasMutex.Lock()
+	defer fake.familySchemasMutex.Unlock()
+	fake.FamilySchemasStub = nil
+	if fake.familySchemasReturnsOnCall == nil {
+		fake.familySchemasReturnsOnCall = make(map[int]struct {
+			result1 []schema.Table
+			result2 error
+		})
+	}
+	fake.familySchemasReturnsOnCall[i] = struct {
+		result1 []schema.Table
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeExecutiveInterface) GetWriterCookie(arg1 string, arg2 string) ([]byte, error) {
@@ -1404,6 +1480,8 @@ func (fake *FakeExecutiveInterface) Invocations() map[string][][]interface{} {
 	defer fake.deleteWriterRateLimitMutex.RUnlock()
 	fake.dropTableMutex.RLock()
 	defer fake.dropTableMutex.RUnlock()
+	fake.familySchemasMutex.RLock()
+	defer fake.familySchemasMutex.RUnlock()
 	fake.getWriterCookieMutex.RLock()
 	defer fake.getWriterCookieMutex.RUnlock()
 	fake.mutateMutex.RLock()

--- a/pkg/schema/table.go
+++ b/pkg/schema/table.go
@@ -1,7 +1,7 @@
 package schema
 
 type Table struct {
-	Family    string     `json:"name"`
+	Family    string     `json:"family"`
 	Name      string     `json:"name"`
 	Fields    [][]string `json:"fields"`
 	KeyFields []string   `json:"keyFields"`


### PR DESCRIPTION
This change adds a new enpoint to the executive that allows the caller to ask for all of the schemas within a particular family.

The motiviation for this change is that it eliminates the need to make many calls when needing to export the schemas for many tables within a particular family.

Testing completed successfully in staging.