### PR TITLE
[WIP] Max max mutation per request configurable.

### DIFF
--- a/pkg/cmd/ctlstore/main.go
+++ b/pkg/cmd/ctlstore/main.go
@@ -76,6 +76,7 @@ type executiveCliConfig struct {
 	Shadow                         bool            `conf:"shadow" help:"set this to true to emit shadow=true metric tags"`
 	Dogstatsd                      dogstatsdConfig `conf:"dogstatsd" help:"dogstatsd Configuration"`
 	EnableDestructiveSchemaChanges bool            `conf:"enable-destructive-schema-changes" help:"Turns on the ability to clear and drop tables from the executive API"`
+	MaxMutateRequestCount          int             `conf:"max-mutate-request-count" help:"The maximum number of mutations allows in any one request"`
 }
 
 // supervisorCliConfig also composes a reflectorCliConfig because it ends up
@@ -392,6 +393,7 @@ func executive(ctx context.Context, args []string) {
 		WarnTableSize:                  50 * units.MEGABYTE,
 		MaxTableSize:                   100 * units.MEGABYTE,
 		EnableDestructiveSchemaChanges: false,
+		MaxMutateRequestCount:          100,
 	}
 
 	loadConfig(&cliCfg, "executive", args)
@@ -422,6 +424,7 @@ func executive(ctx context.Context, args []string) {
 		WriterLimit:                    cliCfg.WriterLimit,
 		WriterLimitPeriod:              cliCfg.WriterLimitPeriod,
 		EnableDestructiveSchemaChanges: cliCfg.EnableDestructiveSchemaChanges,
+		MaxMutateRequestCount:          cliCfg.MaxMutateRequestCount,
 	})
 	if err != nil {
 		errs.IncrDefault(stats.T("op", "startup"))

--- a/pkg/executive/executive_endpoint.go
+++ b/pkg/executive/executive_endpoint.go
@@ -19,9 +19,9 @@ import (
 
 // ExecutiveEndpoint is an HTTP 'wrapper' for ExecutiveInterface
 type ExecutiveEndpoint struct {
-	HealthChecker                  HealthChecker
-	Exec                           ExecutiveInterface
-	EnableDestructiveSchemaChanges bool
+	HealthChecker HealthChecker
+	Exec          ExecutiveInterface
+	config        ExecutiveServiceConfig
 }
 
 func (ee *ExecutiveEndpoint) handleFamilyRoute(w http.ResponseWriter, r *http.Request) {
@@ -480,7 +480,7 @@ func handlingErrorDo(w http.ResponseWriter, fn func() error) {
 }
 
 func (ee *ExecutiveEndpoint) handleDropTable(w http.ResponseWriter, r *http.Request) {
-	if !ee.EnableDestructiveSchemaChanges {
+	if !ee.config.EnableDestructiveSchemaChanges {
 		writeErrorResponse(&errs.BadRequestError{Err: "Dropping tables is not enabled."}, w)
 		return
 	}
@@ -506,7 +506,7 @@ func (ee *ExecutiveEndpoint) handleDropTable(w http.ResponseWriter, r *http.Requ
 }
 
 func (ee *ExecutiveEndpoint) handleClearTableRows(w http.ResponseWriter, r *http.Request) {
-	if !ee.EnableDestructiveSchemaChanges {
+	if !ee.config.EnableDestructiveSchemaChanges {
 		writeErrorResponse(&errs.BadRequestError{Err: "Clearing tables is not enabled."}, w)
 		return
 	}
@@ -532,7 +532,7 @@ func (ee *ExecutiveEndpoint) handleClearTableRows(w http.ResponseWriter, r *http
 }
 
 func (ee *ExecutiveEndpoint) handleClearFamilyRows(w http.ResponseWriter, r *http.Request) {
-	if !ee.EnableDestructiveSchemaChanges {
+	if !ee.config.EnableDestructiveSchemaChanges {
 		writeErrorResponse(&errs.BadRequestError{Err: "Clearing tables is not enabled."}, w)
 		return
 	}

--- a/pkg/limits/limits.go
+++ b/pkg/limits/limits.go
@@ -11,13 +11,9 @@ import (
 )
 
 const (
-	LimitRequestBodySize = 1 * units.MEGABYTE
-	LimitMaxDMLSize      = 768 * units.KILOBYTE
-	LimitFieldValueSize  = 512 * units.KILOBYTE
-
-	LimitMaxMutateRequestCount = 100
+	LimitRequestBodySize       = 1 * units.MEGABYTE
+	LimitMaxDMLSize            = 768 * units.KILOBYTE
 	LimitWriterCookieSize      = 1024
-
 	LimitWriterSecretMaxLength = 100
 	LimitWriterSecretMinLength = 3
 )


### PR DESCRIPTION
In order to allow for more throughput (during backfills for example) we need to make the max number of requests in a
payload configurable in the executive. The previous constant of 100 mutations per request is too limiting. This change keeps that as the normal behavior but also allows it to be configured when starting the executive.