### PR TITLE
Fix `make docker`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine
+FROM golang:1.14-alpine
 ENV SRC github.com/segmentio/ctlstore
 ARG VERSION
 


### PR DESCRIPTION
Seems like an older version of the Go image is required, and there's a `COPY` statement relying on a directory that no longer exists in the `Dockerfile`.
This PR does the bare minimum to get it passing again.

Testing completed successfully locally by @erikdw .