### PR TITLE
[non-prod] add CODEOWNERS file so PRs get assigned automatically

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @erikdw @bartleyg


### PR DESCRIPTION
Testing not required, because this is a change to the repo structure not the code.