### PR TITLE
update segmentio/cli to pick up updated gopkg.in/yaml.v3 to resolve vulnerability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/julienschmidt/httprouter v1.2.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1
 	github.com/pkg/errors v0.9.1
-	github.com/segmentio/cli v0.4.2
+	github.com/segmentio/cli v0.5.1
 	github.com/segmentio/conf v1.1.0
 	github.com/segmentio/errors-go v1.0.0
 	github.com/segmentio/events/v2 v2.3.2

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=
 github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
-github.com/segmentio/cli v0.4.2 h1:Luoliy+hvkDrJZNtppuSxU/njTLysW3lbIq3zCjIEWA=
-github.com/segmentio/cli v0.4.2/go.mod h1:+m0rKUSZsAc4BPzL3Cw9jergrTVzySBdBerJcC/qfes=
+github.com/segmentio/cli v0.5.1 h1:Xhtnmp0LrF+JHQTTV4Q58S79gG8JKXO4MMniyqc+XZs=
+github.com/segmentio/cli v0.5.1/go.mod h1:qz2M+DqXgYnjKLTrcI80MoGQsI6xT0wXCozfBAtF/iI=
 github.com/segmentio/conf v1.1.0 h1:3d8AaXnQNLCze/UpZ31pwDpDj+tmb2FIwroOtqCYNBY=
 github.com/segmentio/conf v1.1.0/go.mod h1:Y3B9O/PqqWqjyxyWWseyj/quPEtMu1zDp/kVbSWWaB0=
 github.com/segmentio/errors-go v1.0.0 h1:B4mbo4hP3+XffV1GhwyAcHlvWoZtYdTyc3BOVPxspTQ=
@@ -183,6 +183,5 @@ gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
# Problem
https://security.snyk.io/vuln/SNYK-GOLANG-GOPKGINYAMLV3-2841557

# Fix
Update the [segmentio/cli](https://github.com/segmentio/cli) dependency to v0.5.1 which has this fix: https://github.com/segmentio/cli/pull/43

# Testing
Testing completed successfully by running `make test` and executing the ctlstore binary.