### PR TITLE
Separate workflows for PR and push steps

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -5,18 +5,24 @@ on:
   pull_request:
     branches: ["**"]
 jobs:
-  publish-arm-ghcr:
+
+  publish-arm-production:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    if: ${{ (github.ref_name == 'master') && (github.event_name == 'push')}}
     steps:
       - uses: actions/checkout@v3
       - name: setup env variables
         id: vars
         run: |
-          echo "SHORT_SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
-      - run: echo "publishing the image ghcr.io/segmentio/ctlstore:${SHORT_SHA}"
+          SHA=${GITHUB_SHA:0:7}
+          echo "TAG=ghcr.io/segmentio/ctlstore:$SHA-arm" >> $GITHUB_ENV
+
+      - name: "Image Name"
+        run: echo "publishing the image ghcr.io/segmentio/ctlstore:${TAG}"
+
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -24,28 +30,51 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: true
-      - run: echo "GHCR LOGIN SUCCESSFUL"
 
-      - if: ${{ (github.ref_name == 'master') && (github.event_name == 'push')}}
-        name: Build and push image for master
+      - name: Build and push image for master
         run: |
           docker context create buildx-build
           docker buildx create --use buildx-build
           docker buildx build \
             --platform=linux/arm64 \
-            -t ghcr.io/segmentio/ctlstore:${SHORT_SHA}-arm \
-            --build-arg VERSION=${SHORT_SHA} \
+            -t ghcr.io/segmentio/ctlstore:${TAG} \
+            --build-arg VERSION=${TAG} \
             --push \
             .
-      - if: ${{ (github.event_name == 'pull_request') }}
-        name: Build and push image for pull request
+
+  publish-arm-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    if: ${{ (github.event_name == 'pull_request') }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup env variables
+        id: vars
+        run: |
+          SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})
+          echo "TAG=ghcr.io/segmentio/ctlstore:$(echo ${GITHUB_HEAD_REF:0:116} | sed 's/[^a-zA-Z0-9]/-/g' )-$SHA-arm" >> $GITHUB_ENV
+
+      - name: "Image Name"
+        run: echo "publishing the image ghcr.io/segmentio/ctlstore:${TAG}"
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          logout: true
+
+      - name: Build and push image for pull request
         run: |
           docker context create buildx-build
           docker buildx create --use buildx-build
           docker buildx build \
             --platform=linux/arm64 \
-            -t ghcr.io/segmentio/ctlstore:$(echo ${GITHUB_HEAD_REF:0:116} | sed 's/[^a-zA-Z0-9]/-/g' )-${SHORT_SHA}-arm \
-            --build-arg VERSION=${SHORT_SHA} \
+            -t $TAG \
+            --build-arg VERSION=${TAG} \
             --push \
             .
       - run: echo "GHCR PUBLISH SUCCESSFUL"

--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -18,10 +18,11 @@ jobs:
         id: vars
         run: |
           SHA=${GITHUB_SHA:0:7}
-          echo "TAG=ghcr.io/segmentio/ctlstore:$SHA-arm" >> $GITHUB_ENV
+          echo "SHA=$SHA" >> $GITHUB_ENV
+          echo "IMAGE=ghcr.io/segmentio/ctlstore:$SHA-arm" >> $GITHUB_ENV
 
       - name: "Image Name"
-        run: echo "publishing the image ghcr.io/segmentio/ctlstore:${TAG}"
+        run: echo "publishing ${IMAGE}"
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -37,8 +38,8 @@ jobs:
           docker buildx create --use buildx-build
           docker buildx build \
             --platform=linux/arm64 \
-            -t ghcr.io/segmentio/ctlstore:${TAG} \
-            --build-arg VERSION=${TAG} \
+            -t ${IMAGE} \
+            --build-arg VERSION=${SHA} \
             --push \
             .
 
@@ -54,10 +55,11 @@ jobs:
         id: vars
         run: |
           SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})
-          echo "TAG=ghcr.io/segmentio/ctlstore:$(echo ${GITHUB_HEAD_REF:0:116} | sed 's/[^a-zA-Z0-9]/-/g' )-$SHA-arm" >> $GITHUB_ENV
+          echo "SHA=$SHA" >> $GITHUB_ENV
+          echo "IMAGE=ghcr.io/segmentio/ctlstore:$(echo ${GITHUB_HEAD_REF:0:116} | sed 's/[^a-zA-Z0-9]/-/g' )-$SHA-arm" >> $GITHUB_ENV
 
       - name: "Image Name"
-        run: echo "publishing the image ghcr.io/segmentio/ctlstore:${TAG}"
+        run: echo "publishing ${IMAGE}"
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -73,8 +75,8 @@ jobs:
           docker buildx create --use buildx-build
           docker buildx build \
             --platform=linux/arm64 \
-            -t $TAG \
-            --build-arg VERSION=${TAG} \
+            -t ${IMAGE} \
+            --build-arg VERSION=${SHA} \
             --push \
             .
       - run: echo "GHCR PUBLISH SUCCESSFUL"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           make build
 
   publish-amd-production:
+    needs: [ build ]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,46 +40,6 @@ jobs:
         run: |
           make build
 
-
-  publish-amd-pr:
-    needs: [ build ]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    if: ${{ (github.event_name == 'pull_request') }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: setup env variables
-        id: vars
-        run: |
-          SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})
-          echo "TAG=ghcr.io/segmentio/ctlstore:$(echo ${GITHUB_HEAD_REF:0:119} | sed 's/[^a-zA-Z0-9]/-/g' )-$SHA" >> $GITHUB_ENV
-
-      - name: "Image Name"
-        run: echo "publishing the image ghcr.io/segmentio/ctlstore:${TAG}"
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          logout: true
-
-      - name: Build and push image for pull request
-        run: |
-          docker context create buildx-build
-          docker buildx create --use buildx-build
-          docker buildx build \
-            --platform=linux/amd64 \
-            -t $TAG \
-            --build-arg VERSION=${TAG} \
-            --push \
-            .
-      - run: echo "GHCR PUBLISH SUCCESSFUL"
-
-
   publish-amd-production:
     runs-on: ubuntu-latest
     permissions:
@@ -92,10 +52,11 @@ jobs:
         id: vars
         run: |
           SHA=${GITHUB_SHA:0:7}
-          echo "TAG=ghcr.io/segmentio/ctlstore:$SHA" >> $GITHUB_ENV
+          echo "SHA=$SHA" >> $GITHUB_ENV
+          echo "IMAGE=ghcr.io/segmentio/ctlstore:$SHA" >> $GITHUB_ENV
 
       - name: "Image Name"
-        run: echo "publishing the image ghcr.io/segmentio/ctlstore:${TAG}"
+        run: echo "publishing ${IMAGE}"
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -111,7 +72,48 @@ jobs:
           docker buildx create --use buildx-build
           docker buildx build \
             --platform=linux/amd64 \
-            -t ghcr.io/segmentio/ctlstore:${TAG} \
-            --build-arg VERSION=${TAG} \
+            -t ${IMAGE} \
+            --build-arg VERSION=${SHA} \
             --push \
             .
+
+  publish-amd-pr:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    if: ${{ (github.event_name == 'pull_request') }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup env variables
+        id: vars
+        run: |
+          SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})
+          echo "SHA=$SHA" >> $GITHUB_ENV
+          echo "IMAGE=ghcr.io/segmentio/ctlstore:$(echo ${GITHUB_HEAD_REF:0:119} | sed 's/[^a-zA-Z0-9]/-/g' )-$SHA" >> $GITHUB_ENV
+
+      - name: "Image Name"
+        run: echo "publishing ${IMAGE}"
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          logout: true
+
+      - name: Build and push image for pull request
+        run: |
+          docker context create buildx-build
+          docker buildx create --use buildx-build
+          docker buildx build \
+            --platform=linux/amd64 \
+            -t ${IMAGE} \
+            --build-arg VERSION=${SHA} \
+            --push \
+            .
+      - run: echo "GHCR PUBLISH SUCCESSFUL"
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,19 +41,24 @@ jobs:
           make build
 
 
-  publish-amd-ghcr:
+  publish-amd-pr:
     needs: [ build ]
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    if: ${{ (github.event_name == 'pull_request') }}
     steps:
       - uses: actions/checkout@v3
       - name: setup env variables
         id: vars
         run: |
-          echo "SHORT_SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
-      - run: echo "publishing the image ghcr.io/segmentio/ctlstore:${SHORT_SHA}"
+          SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})
+          echo "TAG=ghcr.io/segmentio/ctlstore:$(echo ${GITHUB_HEAD_REF:0:119} | sed 's/[^a-zA-Z0-9]/-/g' )-$SHA" >> $GITHUB_ENV
+
+      - name: "Image Name"
+        run: echo "publishing the image ghcr.io/segmentio/ctlstore:${TAG}"
+
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -61,28 +66,52 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: true
-      - run: echo "GHCR LOGIN SUCCESSFUL"
 
-      - if: ${{ (github.ref_name == 'master') && (github.event_name == 'push')}}
-        name: Build and push image for master
+      - name: Build and push image for pull request
         run: |
           docker context create buildx-build
           docker buildx create --use buildx-build
           docker buildx build \
             --platform=linux/amd64 \
-            -t ghcr.io/segmentio/ctlstore:${SHORT_SHA} \
-            --build-arg VERSION=${SHORT_SHA} \
-            --push \
-            .
-      - if: ${{ (github.event_name == 'pull_request') }}
-        name: Build and push image for pull request
-        run: |
-          docker context create buildx-build
-          docker buildx create --use buildx-build
-          docker buildx build \
-            --platform=linux/amd64 \
-            -t ghcr.io/segmentio/ctlstore:$(echo ${GITHUB_HEAD_REF:0:119} | sed 's/[^a-zA-Z0-9]/-/g' )-${SHORT_SHA} \
-            --build-arg VERSION=${SHORT_SHA} \
+            -t $TAG \
+            --build-arg VERSION=${TAG} \
             --push \
             .
       - run: echo "GHCR PUBLISH SUCCESSFUL"
+
+
+  publish-amd-production:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    if: ${{ (github.ref_name == 'master') && (github.event_name == 'push')}}
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup env variables
+        id: vars
+        run: |
+          SHA=${GITHUB_SHA:0:7}
+          echo "TAG=ghcr.io/segmentio/ctlstore:$SHA" >> $GITHUB_ENV
+
+      - name: "Image Name"
+        run: echo "publishing the image ghcr.io/segmentio/ctlstore:${TAG}"
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          logout: true
+
+      - name: Build and push image for master
+        run: |
+          docker context create buildx-build
+          docker buildx create --use buildx-build
+          docker buildx build \
+            --platform=linux/amd64 \
+            -t ghcr.io/segmentio/ctlstore:${TAG} \
+            --build-arg VERSION=${TAG} \
+            --push \
+            .


### PR DESCRIPTION
`github.event.pull_request.head.sha` is only defined (obviously) in Pull Requests. So when attempting to access that context variable after merging into master, the build fails because the value is empty.

These changes will hopefully allow merges into master to actually get the correct tag name.

Testing not required because these are CI changes.