### PR TITLE
[CONFIG-326][stage][prod] Save download metrics and have reflector emitting it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /bin
 .coverprofile
 .vscode
+.idea

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/segmentio/errors-go v1.0.0
 	github.com/segmentio/events/v2 v2.3.2
 	github.com/segmentio/go-sqlite3 v1.12.0
+	github.com/segmentio/objconv v1.0.1
 	github.com/segmentio/stats/v4 v4.6.2
 	github.com/stretchr/testify v1.8.1
 )
@@ -31,7 +32,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e // indirect
 	github.com/segmentio/go-snakecase v1.1.0 // indirect
-	github.com/segmentio/objconv v1.0.1 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/segmentio/errors-go v1.0.0
 	github.com/segmentio/events/v2 v2.3.2
 	github.com/segmentio/go-sqlite3 v1.12.0
-	github.com/segmentio/objconv v1.0.1
 	github.com/segmentio/stats/v4 v4.6.2
 	github.com/stretchr/testify v1.8.1
 )
@@ -32,6 +31,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e // indirect
 	github.com/segmentio/go-snakecase v1.1.0 // indirect
+	github.com/segmentio/objconv v1.0.1 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/pkg/reflector/download.go
+++ b/pkg/reflector/download.go
@@ -3,11 +3,8 @@ package reflector
 import (
 	"bytes"
 	"compress/gzip"
-	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -32,11 +29,6 @@ type S3Downloader struct {
 	Key                 string
 	S3Client            S3Client
 	StartOverOnNotFound bool // whether we should rebuild LDB if snapshot not found
-}
-
-type DownloadMetric struct {
-	StartTime  string `json:"startTime"`
-	Downloaded string `json:"downloaded"`
 }
 
 func (d *S3Downloader) DownloadTo(w io.Writer) (n int64, err error) {
@@ -80,46 +72,7 @@ func (d *S3Downloader) DownloadTo(w io.Writer) (n int64, err error) {
 		events.Log("LDB inflated %d -> %d bytes", *compressedSize, n)
 	}
 
-	_ = d.emitMetricFromFile()
-
 	return
-}
-
-func (d *S3Downloader) emitMetricFromFile() error {
-	name := "/var/spool/ctlstore/metrics.json"
-	metricsFile, err := os.Open(name)
-	defer func() {
-		err = os.Remove(name)
-	}()
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		err = metricsFile.Close()
-	}()
-	if err != nil {
-		return err
-	}
-
-	b, err := ioutil.ReadAll(metricsFile)
-	if err != nil {
-		return err
-	}
-
-	var dm DownloadMetric
-
-	err = json.Unmarshal(b, &dm)
-	if err != nil {
-		return err
-	}
-
-	stats.Observe("init_snapshot_download_time", dm.StartTime, stats.Tag{
-		Name:  "downloaded",
-		Value: dm.Downloaded,
-	})
-
-	return nil
 }
 
 func (d *S3Downloader) getS3Client() (S3Client, error) {

--- a/pkg/reflector/reflector.go
+++ b/pkg/reflector/reflector.go
@@ -75,7 +75,7 @@ type ReflectorConfig struct {
 }
 
 type DownloadMetric struct {
-	StartTime   string `json:"startTime"`
+	StartTime   int    `json:"startTime"`
 	Downloaded  string `json:"downloaded"`
 	Compressed  string `json:"compressed"`
 	Concurrency string `json:"concurrency"`
@@ -324,7 +324,7 @@ func emitMetricFromFile() error {
 		return err
 	}
 
-	stats.Observe("ctlstore.reflector.init_snapshot_download_time", dm.StartTime, stats.Tag{
+	stats.Observe("init_snapshot_download_time", dm.StartTime, stats.Tag{
 		Name:  "downloaded",
 		Value: dm.Downloaded,
 	}, stats.Tag{
@@ -334,7 +334,6 @@ func emitMetricFromFile() error {
 		Name:  "concurrency",
 		Value: dm.Concurrency,
 	})
-	stats.Flush()
 
 	return nil
 }

--- a/pkg/reflector/reflector.go
+++ b/pkg/reflector/reflector.go
@@ -184,7 +184,7 @@ func ReflectorFromConfig(config ReflectorConfig) (*Reflector, error) {
 
 	err = emitMetricFromFile()
 	if err != nil {
-		return nil, errors.Wrap(err, "Fail to emit metric from file")
+		events.Debug("Failed to emit metric from file", err)
 	}
 
 	// TODO: check Upstream fields

--- a/pkg/reflector/reflector.go
+++ b/pkg/reflector/reflector.go
@@ -185,7 +185,7 @@ func ReflectorFromConfig(config ReflectorConfig) (*Reflector, error) {
 
 	err = emitMetricFromFile()
 	if err != nil {
-		events.Debug("Failed to emit metric from file", err)
+		events.Log("Failed to emit metric from file", err)
 	}
 	events.Log("Successfully emitted metric from file")
 
@@ -297,8 +297,11 @@ func ReflectorFromConfig(config ReflectorConfig) (*Reflector, error) {
 func emitMetricFromFile() error {
 	path := "/var/spool/ctlstore/metrics.json"
 	if _, err := os.Stat(path); err != nil {
-		if os.IsNotExist(err) {
+		switch {
+		case os.IsNotExist(err):
 			return nil
+		default:
+			return err
 		}
 	}
 

--- a/pkg/reflector/reflector.go
+++ b/pkg/reflector/reflector.go
@@ -75,8 +75,10 @@ type ReflectorConfig struct {
 }
 
 type DownloadMetric struct {
-	StartTime  string `json:"startTime"`
-	Downloaded string `json:"downloaded"`
+	StartTime   string `json:"startTime"`
+	Downloaded  string `json:"downloaded"`
+	Compressed  string `json:"compressed"`
+	Concurrency string `json:"concurrency"`
 }
 
 type starter interface {
@@ -325,6 +327,12 @@ func emitMetricFromFile() error {
 	stats.Observe("reflector.init_snapshot_download_time", dm.StartTime, stats.Tag{
 		Name:  "downloaded",
 		Value: dm.Downloaded,
+	}, stats.Tag{
+		Name:  "compressed",
+		Value: dm.Compressed,
+	}, stats.Tag{
+		Name:  "concurrency",
+		Value: dm.Concurrency,
 	})
 
 	return nil

--- a/pkg/reflector/reflector.go
+++ b/pkg/reflector/reflector.go
@@ -186,6 +186,7 @@ func ReflectorFromConfig(config ReflectorConfig) (*Reflector, error) {
 	if err != nil {
 		events.Debug("Failed to emit metric from file", err)
 	}
+	events.Log("Successfully emitted metric from file")
 
 	// TODO: check Upstream fields
 
@@ -321,7 +322,7 @@ func emitMetricFromFile() error {
 		return err
 	}
 
-	stats.Observe("init_snapshot_download_time", dm.StartTime, stats.Tag{
+	stats.Observe("reflector.init_snapshot_download_time", dm.StartTime, stats.Tag{
 		Name:  "downloaded",
 		Value: dm.Downloaded,
 	})

--- a/pkg/reflector/reflector.go
+++ b/pkg/reflector/reflector.go
@@ -324,7 +324,7 @@ func emitMetricFromFile() error {
 		return err
 	}
 
-	stats.Observe("reflector.init_snapshot_download_time", dm.StartTime, stats.Tag{
+	stats.Observe("ctlstore.reflector.init_snapshot_download_time", dm.StartTime, stats.Tag{
 		Name:  "downloaded",
 		Value: dm.Downloaded,
 	}, stats.Tag{
@@ -334,6 +334,7 @@ func emitMetricFromFile() error {
 		Name:  "concurrency",
 		Value: dm.Concurrency,
 	})
+	stats.Flush()
 
 	return nil
 }

--- a/pkg/reflector/reflector.go
+++ b/pkg/reflector/reflector.go
@@ -311,11 +311,6 @@ func emitMetricFromFile() error {
 		return err
 	}
 
-	defer func() {
-		metricsFile.Close()
-		os.Remove(path)
-	}()
-
 	b, err := io.ReadAll(metricsFile)
 	if err != nil {
 		return err
@@ -331,6 +326,11 @@ func emitMetricFromFile() error {
 	}
 
 	stats.Observe("init_snapshot_download_time", dm.StartTime, stats.T("downloaded", dm.Downloaded), stats.T("compressed", dm.Compressed))
+
+	defer func() {
+		metricsFile.Close()
+		os.Remove(path)
+	}()
 
 	return nil
 }

--- a/pkg/reflector/reflector.go
+++ b/pkg/reflector/reflector.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -294,23 +293,24 @@ func ReflectorFromConfig(config ReflectorConfig) (*Reflector, error) {
 }
 
 func emitMetricFromFile() error {
-	name := "/var/spool/ctlstore/metrics.json"
-	metricsFile, err := os.Open(name)
-	defer func() {
-		err = os.Remove(name)
-	}()
+	path := "/var/spool/ctlstore/metrics.json"
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+	}
+
+	metricsFile, err := os.Open(path)
 	if err != nil {
 		return err
 	}
 
 	defer func() {
-		err = metricsFile.Close()
+		metricsFile.Close()
+		os.Remove(path)
 	}()
-	if err != nil {
-		return err
-	}
 
-	b, err := ioutil.ReadAll(metricsFile)
+	b, err := io.ReadAll(metricsFile)
 	if err != nil {
 		return err
 	}

--- a/pkg/reflector/reflector.go
+++ b/pkg/reflector/reflector.go
@@ -184,7 +184,8 @@ func ReflectorFromConfig(config ReflectorConfig) (*Reflector, error) {
 
 	events.Log("Max known ledger sequence: %{seq}d", maxKnownSeq)
 
-	err = emitMetricFromFile()
+	path := "/var/spool/ctlstore/metrics.json"
+	err = emitMetricFromFile(path)
 	if err != nil {
 		events.Log("Failed to emit metric from file", err)
 	}
@@ -295,8 +296,7 @@ func ReflectorFromConfig(config ReflectorConfig) (*Reflector, error) {
 	}, nil
 }
 
-func emitMetricFromFile() error {
-	path := "/var/spool/ctlstore/metrics.json"
+func emitMetricFromFile(path string) error {
 	if _, err := os.Stat(path); err != nil {
 		switch {
 		case os.IsNotExist(err):

--- a/pkg/reflector/reflector_test.go
+++ b/pkg/reflector/reflector_test.go
@@ -274,10 +274,10 @@ func TestEmitMetricFromFile(t *testing.T) {
 
 			err = emitMetricFromFile()
 
-			if test.err == nil {
-				require.NoError(t, err)
-			} else {
+			if err != nil {
 				require.Contains(t, err.Error(), test.err.Error())
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/pkg/reflector/reflector_test.go
+++ b/pkg/reflector/reflector_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/base64"
+	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -267,8 +268,10 @@ func TestEmitMetricFromFile(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			os.Remove("/var/spool/ctlstore/metrics.json")
 			err := os.WriteFile(test.path, []byte(test.content), os.FileMode(test.perm))
+			assert.NoError(t, err)
+			defer os.Remove("/var/spool/ctlstore/metrics.json")
+
 			err = emitMetricFromFile()
 
 			if test.err == nil {

--- a/pkg/reflector/reflector_test.go
+++ b/pkg/reflector/reflector_test.go
@@ -274,6 +274,7 @@ func TestEmitMetricFromFile(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			tempdir := t.TempDir()
 			f, err := os.CreateTemp(tempdir, test.fileName)
 			assert.NoError(t, err)

--- a/pkg/reflector/reflector_test.go
+++ b/pkg/reflector/reflector_test.go
@@ -268,9 +268,9 @@ func TestEmitMetricFromFile(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			os.Remove("/var/spool/ctlstore/metrics.json")
 			err := os.WriteFile(test.path, []byte(test.content), os.FileMode(test.perm))
 			assert.NoError(t, err)
-			defer os.Remove("/var/spool/ctlstore/metrics.json")
 
 			err = emitMetricFromFile()
 

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -52,4 +52,4 @@ emit_metrics(){
   fi
 }
 
-emit_metrics &
+emit_metrics

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -35,5 +35,5 @@ else
   echo "Snapshot already present"
 fi
 
-echo "{\"startTime\": $(($END - $START)), \"downloaded\": $DOWNLOADED}" > $METRICS
+echo "{\"startTime\": $(($END - $START)), \"downloaded\": \"$DOWNLOADED\"}" > $METRICS
 cat $METRICS

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -32,5 +32,5 @@ else
   echo "Snapshot already present"
 fi
 
-echo "{\"startTime\": $(($END - $START)), \"downloaded\": \"$DOWNLOADED\", \"compressed\": \"$COMPRESSED\", \"concurrency\": \"$CONCURRENCY\"}" > $METRICS
+echo "{\"startTime\": $(($END - $START)), \"downloaded\": \"$DOWNLOADED\", \"compressed\": \"$COMPRESSED\"}" > $METRICS
 cat $METRICS

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -37,5 +37,5 @@ fi
 if [ ! -z "$STATS_IP" ]; then
   METRICS="/var/spool/ctlstore/metrics"
   echo "{'startTime': $(($END - $START))}" > $METRICS
-  cat METRICS
+  cat $METRICS
 fi

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -34,15 +34,16 @@ else
   echo "Snapshot already present"
 fi
 
+COUNTER=0
 if [ ! -z "$STATS_IP" ]; then
-  counter=0
 #  while ! echo exit | nc -u $NODE_IP $STATS_PORT;
   while true;
-  if (($((counter % 15)) == 0)); then
+  echo $COUNTER
+  if (($((COUNTER % 15)) == 0)); then
     echo "awaiting datadog UDP port to be ready..."
   fi
-  counter=$((counter+1))
-  if ((counter > 30)); then
+  COUNTER=$((COUNTER+1))
+  if ((COUNTER > 30)); then
     break;
   fi
   do sleep 1;

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -39,11 +39,11 @@ if [ ! -z "$STATS_IP" ]; then
 #  while ! echo exit | nc -u $NODE_IP $STATS_PORT;
   while true;
   echo $COUNTER
-  if (($((COUNTER % 15)) == 0)); then
+  if [ $(($COUNTER % 15)) -eq 0 ]; then
     echo "awaiting datadog UDP port to be ready..."
   fi
-  COUNTER=$((COUNTER+1))
-  if ((COUNTER > 30)); then
+  COUNTER=$(($COUNTER+1))
+  if [ $COUNTER -gt 30 ]; then
     break;
   fi
   do sleep 1;

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -4,12 +4,12 @@ set -eo pipefail
 
 CTLSTORE_BOOTSTRAP_URL=$1
 CONCURRENCY=${2:-20}
+DOWNLOADED="false"
+COMPRESSED="false"
+METRICS="/var/spool/ctlstore/metrics.json"
 
-TAGS="downloaded:false"
 START=$(date +%s)
 END=$(date +%s)
-METRICS="/var/spool/ctlstore/metrics.json"
-DOWNLOADED="false"
 if [ ! -f /var/spool/ctlstore/ldb.db ]; then
   # busybox does not support sub-second resolution
   START=$(date +%s)
@@ -18,15 +18,12 @@ if [ ! -f /var/spool/ctlstore/ldb.db ]; then
   cd /var/spool/ctlstore
   s5cmd -r 0 --log debug cp --concurrency $CONCURRENCY $CTLSTORE_BOOTSTRAP_URL .
 
-  TAGS="downloaded:true"
   DOWNLOADED="true"
   if [[ ${CTLSTORE_BOOTSTRAP_URL: -2} == gz ]]; then
     echo "Decompressing"
     pigz -d snapshot.db.gz
-    TAGS="$TAGS,compressed:true"
+    COMPRESSED="true"
   fi
-
-  TAGS="$TAGS,concurrency:$CONCURRENCY"
 
   mv snapshot.db ldb.db
   END=$(date +%s)
@@ -35,5 +32,5 @@ else
   echo "Snapshot already present"
 fi
 
-echo "{\"startTime\": $(($END - $START)), \"downloaded\": \"$DOWNLOADED\"}" > $METRICS
+echo "{\"startTime\": $(($END - $START)), \"downloaded\": \"$DOWNLOADED\", \"compressed\": \"$COMPRESSED\", \"concurrency\": \"$CONCURRENCY\"}" > $METRICS
 cat $METRICS

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -37,7 +37,7 @@ fi
 emit_metrics(){
   if [ ! -z "$STATS_IP" ]; then
     counter=0
-    while ! echo exit | nc -u -w1 $NODE_IP $STATS_PORT;
+    while ! echo exit | nc -u $NODE_IP $STATS_PORT;
     if (($((counter % 15)) == 0)); then
       echo "awaiting datadog UDP port to be ready..."
     fi

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -35,16 +35,18 @@ else
 fi
 
 COUNTER=0
-if [ ! -z "$STATS_IP" ]; then
-  while ! echo exit | nc -u -w1 $NODE_IP $STATS_PORT;
+if [ -z "$STATS_IP" ]; then
+  while true;
   echo $COUNTER
-  if [ $(($COUNTER % 8)) -eq 0 ]; then
+  nc -zu $NODE_IP $STATS_PORT
+  if [ $? = 0 ] || [ $COUNTER -gt 300 ]; then
+    break
+  fi
+
+  if [ $(($COUNTER % 15)) -eq 0 ]; then
     echo "awaiting datadog UDP port to be ready..."
   fi
   COUNTER=$(($COUNTER+1))
-  if [ $COUNTER -gt 150 ]; then
-    break;
-  fi
   do sleep 1;
   done
 

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -36,13 +36,13 @@ fi
 
 COUNTER=0
 if [ ! -z "$STATS_IP" ]; then
-  while ! echo exit | nc -u $NODE_IP $STATS_PORT;
+  while ! echo exit | nc -u -w1 $NODE_IP $STATS_PORT;
   echo $COUNTER
-  if [ $(($COUNTER % 15)) -eq 0 ]; then
+  if [ $(($COUNTER % 8)) -eq 0 ]; then
     echo "awaiting datadog UDP port to be ready..."
   fi
   COUNTER=$(($COUNTER+1))
-  if [ $COUNTER -gt 30 ]; then
+  if [ $COUNTER -gt 150 ]; then
     break;
   fi
   do sleep 1;

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -45,11 +45,20 @@ if [ ! -f /var/spool/ctlstore/ldb.db ]; then
     COUNTER=$(($COUNTER+1))
     do sleep 1;
     done
-    echo "ctlstore.reflector.init_snapshot_download_time:$(($END - $START))|h|#$TAGS"
+    # experiment
     echo $NODE_IP
     echo $STATS_PORT
-    echo "UDP port ready, awaiting for 10 seconds..";
-    sleep 10;
+    FAKETIME=0
+    while true;
+    do sleep 10;
+    FAKETIME=$(($FAKETIME+10))
+    echo -n "ctlstore.reflector.init_snapshot_download_time:$(($FAKETIME))|h|#$TAGS" | nc -u -w1 $NODE_IP $STATS_PORT
+    if [ $FAKETIME -gt 1200 ]; then
+      break
+    fi
+    done
+    # experiment
+
     echo -n "ctlstore.reflector.init_snapshot_download_time:$(($END - $START))|h|#$TAGS" | nc -u -w1 $NODE_IP $STATS_PORT
   fi
 else

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -34,8 +34,8 @@ else
   echo "Snapshot already present"
 fi
 
-if [ ! -z "$STATS_IP" ]; then
-  METRICS="/var/spool/ctlstore/metrics"
-  echo "{'startTime': $(($END - $START))}" > $METRICS
+if [ -z "$STATS_IP" ]; then
+  METRICS="/var/spool/ctlstore/metrics.json"
+  echo "{\"startTime\": $(($END - $START)), \"downloaded\": true}" > $METRICS
   cat $METRICS
 fi

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -36,8 +36,7 @@ fi
 
 COUNTER=0
 if [ ! -z "$STATS_IP" ]; then
-#  while ! echo exit | nc -u $NODE_IP $STATS_PORT;
-  while true;
+  while ! echo exit | nc -u $NODE_IP $STATS_PORT;
   echo $COUNTER
   if [ $(($COUNTER % 15)) -eq 0 ]; then
     echo "awaiting datadog UDP port to be ready..."

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -30,37 +30,12 @@ if [ ! -f /var/spool/ctlstore/ldb.db ]; then
   mv snapshot.db ldb.db
   END=$(date +%s)
   echo "ldb.db ready in $(($END - $START)) seconds"
-
-  COUNTER=0
-  if [ ! -z "$STATS_IP" ]; then
-    while true;
-    nc -zu $NODE_IP $STATS_PORT
-    if [ $? = 0 ] || [ $COUNTER -gt 300 ]; then
-      break
-    fi
-
-    if [ $(($COUNTER % 15)) -eq 0 ]; then
-      echo "awaiting datadog UDP port to be ready..."
-    fi
-    COUNTER=$(($COUNTER+1))
-    do sleep 1;
-    done
-    # experiment
-    echo $NODE_IP
-    echo $STATS_PORT
-    FAKETIME=0
-    while true;
-    do sleep 10;
-    FAKETIME=$(($FAKETIME+10))
-    echo -n "ctlstore.reflector.init_snapshot_download_time:$(($FAKETIME))|h|#$TAGS" | nc -u -w1 $NODE_IP $STATS_PORT
-    if [ $FAKETIME -gt 1200 ]; then
-      break
-    fi
-    done
-    # experiment
-
-    echo -n "ctlstore.reflector.init_snapshot_download_time:$(($END - $START))|h|#$TAGS" | nc -u -w1 $NODE_IP $STATS_PORT
-  fi
 else
   echo "Snapshot already present"
+fi
+
+if [ ! -z "$STATS_IP" ]; then
+  METRICS="/var/spool/ctlstore/metrics"
+  echo "{'startTime': $(($END - $START))}" > $METRICS
+  cat METRICS
 fi

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -36,12 +36,13 @@ fi
 
 if [ ! -z "$STATS_IP" ]; then
   counter=0
-  while ! echo exit | nc -u $NODE_IP $STATS_PORT;
+#  while ! echo exit | nc -u $NODE_IP $STATS_PORT;
+  while true;
   if (($((counter % 15)) == 0)); then
     echo "awaiting datadog UDP port to be ready..."
   fi
   counter=$((counter+1))
-  if ((counter > 300)); then
+  if ((counter > 30)); then
     break;
   fi
   do sleep 1;

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -37,23 +37,18 @@ fi
 emit_metrics(){
   if [ ! -z "$STATS_IP" ]; then
     counter=0
-    emit=true
     while ! echo exit | nc -u -w1 $NODE_IP $STATS_PORT;
     if (($((counter % 15)) == 0)); then
       echo "awaiting datadog UDP port to be ready..."
     fi
     counter=$((counter+1))
-    if ((counter > 360)); then
-      emit=false
-      echo "unable to connect to UDP port."
+    if ((counter > 300)); then
       break;
     fi
     do sleep 1;
     done
 
-    if [ "$emit" = true ]; then
-      echo -n "ctlstore.reflector.init_snapshot_download_time:$(($END - $START))|h|#$TAGS" | nc -u -w1 $NODE_IP $STATS_PORT
-    fi
+    echo -n "ctlstore.reflector.init_snapshot_download_time:$(($END - $START))|h|#$TAGS" | nc -u -w1 $NODE_IP $STATS_PORT
   fi
 }
 

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -4,12 +4,12 @@ set -eo pipefail
 
 CTLSTORE_BOOTSTRAP_URL=$1
 CONCURRENCY=${2:-20}
-STATS_IP=$3
-STATS_PORT=${4:-8125}
 
 TAGS="downloaded:false"
 START=$(date +%s)
 END=$(date +%s)
+METRICS="/var/spool/ctlstore/metrics.json"
+DOWNLOADED="false"
 if [ ! -f /var/spool/ctlstore/ldb.db ]; then
   # busybox does not support sub-second resolution
   START=$(date +%s)
@@ -19,6 +19,7 @@ if [ ! -f /var/spool/ctlstore/ldb.db ]; then
   s5cmd -r 0 --log debug cp --concurrency $CONCURRENCY $CTLSTORE_BOOTSTRAP_URL .
 
   TAGS="downloaded:true"
+  DOWNLOADED="true"
   if [[ ${CTLSTORE_BOOTSTRAP_URL: -2} == gz ]]; then
     echo "Decompressing"
     pigz -d snapshot.db.gz
@@ -34,8 +35,5 @@ else
   echo "Snapshot already present"
 fi
 
-if [ -z "$STATS_IP" ]; then
-  METRICS="/var/spool/ctlstore/metrics.json"
-  echo "{\"startTime\": $(($END - $START)), \"downloaded\": true}" > $METRICS
-  cat $METRICS
-fi
+echo "{\"startTime\": $(($END - $START)), \"downloaded\": $DOWNLOADED}" > $METRICS
+cat $METRICS

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -35,5 +35,8 @@ else
 fi
 
 if [ ! -z "$STATS_IP" ]; then
+  while ! echo exit | nc -u -w1 $NODE_IP $STATS_PORT;
+  do sleep 120;
+  done
   echo -n "ctlstore.reflector.init_snapshot_download_time:$(($END - $START))|h|#$TAGS" | nc -u -w1 $NODE_IP $STATS_PORT
 fi

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -35,9 +35,8 @@ else
 fi
 
 COUNTER=0
-if [ -z "$STATS_IP" ]; then
+if [ ! -z "$STATS_IP" ]; then
   while true;
-  echo $COUNTER
   nc -zu $NODE_IP $STATS_PORT
   if [ $? = 0 ] || [ $COUNTER -gt 300 ]; then
     break

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -48,6 +48,7 @@ if [ ! -z "$STATS_IP" ]; then
   COUNTER=$(($COUNTER+1))
   do sleep 1;
   done
-
+  echo "UDP port ready, awaiting for 10 seconds..";
+  sleep 10;
   echo -n "ctlstore.reflector.init_snapshot_download_time:$(($END - $START))|h|#$TAGS" | nc -u -w1 $NODE_IP $STATS_PORT
 fi

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -34,22 +34,18 @@ else
   echo "Snapshot already present"
 fi
 
-emit_metrics(){
-  if [ ! -z "$STATS_IP" ]; then
-    counter=0
-    while ! echo exit | nc -u $NODE_IP $STATS_PORT;
-    if (($((counter % 15)) == 0)); then
-      echo "awaiting datadog UDP port to be ready..."
-    fi
-    counter=$((counter+1))
-    if ((counter > 300)); then
-      break;
-    fi
-    do sleep 1;
-    done
-
-    echo -n "ctlstore.reflector.init_snapshot_download_time:$(($END - $START))|h|#$TAGS" | nc -u -w1 $NODE_IP $STATS_PORT
+if [ ! -z "$STATS_IP" ]; then
+  counter=0
+  while ! echo exit | nc -u $NODE_IP $STATS_PORT;
+  if (($((counter % 15)) == 0)); then
+    echo "awaiting datadog UDP port to be ready..."
   fi
-}
+  counter=$((counter+1))
+  if ((counter > 300)); then
+    break;
+  fi
+  do sleep 1;
+  done
 
-emit_metrics
+  echo -n "ctlstore.reflector.init_snapshot_download_time:$(($END - $START))|h|#$TAGS" | nc -u -w1 $NODE_IP $STATS_PORT
+fi


### PR DESCRIPTION
Save the downloading time to a local file, and have ctlstore-reflector detect that file and emit it later to Datadog agent.

Testing completed successfully in stage by deploying and restart a pod, metrics showed successfully in dashboard:
<img width="431" alt="Screenshot 2023-08-24 at 1 54 07 PM" src="https://github.com/segmentio/ctlstore/assets/6007569/521c5df1-384b-4d0c-9f58-c58eda3f2c2b">

- [ ] Deploy and rotate a node, the metric didn't get through to the dashboard, we believe it's a race condition that metric emitting beats the readiness of the DD agent, active discussion with O11y team: https://twilio.slack.com/archives/CPLTV1V9A/p1691768630711249
