### PR TITLE
[CF-296] start up multiple reflectors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/segmentio/go-sqlite3 v1.12.0
 	github.com/segmentio/stats/v4 v4.6.2
 	github.com/stretchr/testify v1.8.1
+	golang.org/x/sync v0.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/ldb_reader.go
+++ b/ldb_reader.go
@@ -46,6 +46,11 @@ var (
 	ErrNoLedgerUpdates      = errors.New("no ledger updates have been received yet")
 )
 
+type RowRetriever interface {
+	GetRowsByKeyPrefix(ctx context.Context, familyName string, tableName string, key ...interface{}) (*Rows, error)
+	GetRowByKey(ctx context.Context, out interface{}, familyName string, tableName string, key ...interface{}) (found bool, err error)
+}
+
 func newLDBReader(path string) (*LDBReader, error) {
 	db, err := newLDB(path)
 	if err != nil {
@@ -369,7 +374,7 @@ func (reader *LDBReader) Ping(ctx context.Context) bool {
 // to the type of each PK column.
 func convertKeyBeforeQuery(pk schema.PrimaryKey, key []interface{}) error {
 	for i, k := range key {
-		// sanity check on th elength of the pk field type slice
+		// sanity check on the length of the pk field type slice
 		if i >= len(pk.Types) {
 			return errors.New("insufficient key field type data")
 		}

--- a/ldb_rotating_reader.go
+++ b/ldb_rotating_reader.go
@@ -1,0 +1,129 @@
+package ctlstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// LDBRotatingReader reads data from multiple LDBs on a rotating schedule.
+// The main benefit is relieving read pressure on a particular ldb file when it becomes inactive,
+// allowing sqlite maintenance
+type LDBRotatingReader struct {
+	active           atomic.Int32
+	dbs              []RowRetriever
+	mu               sync.RWMutex
+	cancelWatcher    context.CancelFunc
+	rotationsPerHour RotationFrequency
+	schedule         []int8
+	now              func() time.Time
+	tickerInterval   time.Duration
+}
+
+type RotationFrequency int
+
+const (
+	// Every30 rotate on 30 minute mark in an hour
+	Every30 RotationFrequency = 30
+	// Every20 rotate on 20 minute marks in an hour
+	Every20 RotationFrequency = 20
+	// Every15 rotate on 15 minute marks in an hour
+	Every15 RotationFrequency = 15
+	// Every10 rotate on 10 minute marks in an hour
+	Every10 RotationFrequency = 10
+	// Every6 rotate on 6 minute marks in an hour
+	Every6 RotationFrequency = 6
+)
+
+// RotatingReader creates a new reader that rotates which ldb it reads from on a rotation frequency
+func RotatingReader(ctx context.Context, rotationsPerHour RotationFrequency, ldbPaths ...string) (RowRetriever, error) {
+	r, err := rotatingReader(rotationsPerHour, ldbPaths...)
+	if err != nil {
+		return nil, err
+	}
+	r.setActive()
+	go r.rotate(ctx)
+	return r, nil
+}
+
+func rotatingReader(rotationsPerHour RotationFrequency, ldbPaths ...string) (*LDBRotatingReader, error) {
+	if len(ldbPaths) < 2 {
+		return nil, errors.New("RotatingReader requires more than 1 ldb")
+	}
+	if !isValid(rotationsPerHour) {
+		return nil, errors.New(fmt.Sprintf("invalid rotation frequency: %v", rotationsPerHour))
+	}
+	if len(ldbPaths) > int(rotationsPerHour) {
+		return nil, errors.New("cannot have more ldbs than rotations per hour")
+	}
+	var r LDBRotatingReader
+	for _, p := range ldbPaths {
+		reader, err := newLDBReader(p)
+		if err != nil {
+			return nil, err
+		}
+		r.dbs = append(r.dbs, reader)
+	}
+	r.schedule = make([]int8, 60)
+	idx := 0
+	for i := 1; i < 61; i++ {
+		r.schedule[i-1] = int8(idx % len(ldbPaths))
+		if i%int(rotationsPerHour) == 0 {
+			idx++
+		}
+	}
+	return &r, nil
+}
+
+func (r *LDBRotatingReader) setActive() {
+	if r.now == nil {
+		r.now = time.Now
+	}
+	r.active.Store(int32(r.schedule[r.now().Minute()]))
+}
+
+// GetRowsByKeyPrefix delegates to the active LDBReader
+func (r *LDBRotatingReader) GetRowsByKeyPrefix(ctx context.Context, familyName string, tableName string, key ...interface{}) (*Rows, error) {
+	return r.dbs[r.active.Load()].GetRowsByKeyPrefix(ctx, familyName, tableName, key...)
+}
+
+// GetRowByKey delegates to the active LDBReader
+func (r *LDBRotatingReader) GetRowByKey(ctx context.Context, out interface{}, familyName string, tableName string, key ...interface{}) (found bool, err error) {
+	return r.dbs[r.active.Load()].GetRowByKey(ctx, out, familyName, tableName, key...)
+}
+
+func (r *LDBRotatingReader) rotate(ctx context.Context) {
+	if r.tickerInterval == 0 {
+		r.tickerInterval = 1 * time.Minute
+	}
+	ticker := time.NewTicker(r.tickerInterval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			next := r.schedule[r.now().Minute()]
+			r.active.Swap(int32(next))
+		}
+	}
+}
+
+func isValid(rf RotationFrequency) bool {
+	switch rf {
+	case Every10:
+		fallthrough
+	case Every20:
+		fallthrough
+	case Every30:
+		fallthrough
+	case Every15:
+		fallthrough
+	case Every6:
+		return true
+	}
+	return false
+}

--- a/ldb_rotating_reader.go
+++ b/ldb_rotating_reader.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/segmentio/ctlstore/pkg/ldb"
+	"github.com/segmentio/events/v2"
 	"github.com/segmentio/stats/v4"
 	"sync/atomic"
 	"time"
@@ -77,6 +78,7 @@ func rotatingReader(minutesPerRotation RotationPeriod, ldbPaths ...string) (*LDB
 	}
 	var r LDBRotatingReader
 	for _, p := range ldbPaths {
+		events.Log("Opening ldb %s for reading", p)
 		reader, err := newLDBReader(p)
 		if err != nil {
 			return nil, err

--- a/ldb_rotating_reader.go
+++ b/ldb_rotating_reader.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/segmentio/ctlstore/pkg/globalstats"
 	"github.com/segmentio/ctlstore/pkg/ldb"
 	"github.com/segmentio/events/v2"
 	"github.com/segmentio/stats/v4"
@@ -129,6 +130,7 @@ func (r *LDBRotatingReader) rotate(ctx context.Context) {
 			if int32(next) != atomic.LoadInt32(&r.active) {
 				atomic.StoreInt32(&r.active, int32(next))
 				stats.Incr("rotating_reader.rotate")
+				globalstats.Set("rotating_reader.active", next)
 			}
 		}
 	}

--- a/ldb_rotating_reader.go
+++ b/ldb_rotating_reader.go
@@ -45,7 +45,7 @@ const (
 func defaultPaths(count int) []string {
 	paths := []string{defaultPath}
 	for i := 1; i < count; i++ {
-		paths = append(paths, fmt.Sprintf(ldbFormat, i))
+		paths = append(paths, fmt.Sprintf(ldbFormat, i+1))
 	}
 	return paths
 }

--- a/ldb_rotating_reader_test.go
+++ b/ldb_rotating_reader_test.go
@@ -366,7 +366,7 @@ func TestPath(t *testing.T) {
 	}
 
 	for i := 1; i < 5; i++ {
-		if !strings.Contains(paths[i], strconv.Itoa(i)) {
+		if !strings.Contains(paths[i], strconv.Itoa(i+1)) {
 			t.Errorf("path %s should've contained its number, %d", paths[i], i)
 		}
 	}

--- a/ldb_rotating_reader_test.go
+++ b/ldb_rotating_reader_test.go
@@ -1,0 +1,344 @@
+package ctlstore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"github.com/segmentio/ctlstore/pkg/ldb"
+	"github.com/stretchr/testify/require"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func getMultiDBs(t *testing.T, count int) (dbs []*sql.DB, paths []string) {
+	var tds []func()
+	for i := 0; i < count; i++ {
+		d, td, p := ldb.LDBForTestWithPath(t)
+		dbs = append(dbs, d)
+		tds = append(tds, td)
+		paths = append(paths, p)
+	}
+	t.Cleanup(func() {
+		for _, fn := range tds {
+			fn()
+		}
+	})
+	return dbs, paths
+}
+
+type basic struct {
+	x int `ctlstore:"x"`
+}
+
+func TestBasicRotatingReader(t *testing.T) {
+	dbs, paths := getMultiDBs(t, 2)
+	for i, db := range dbs {
+		_, err := db.Exec("CREATE TABLE family___table (x integer primary key);")
+		if err != nil {
+			t.Fatalf("failed to setup table: %v", err)
+		}
+		_, err = db.Exec(fmt.Sprintf("INSERT INTO family___table VALUES ('%d')", i+1))
+		if err != nil {
+			t.Fatalf("failed to insert into table: %v", err)
+		}
+	}
+
+	rr, err := RotatingReader(context.Background(), Every30, paths...)
+	if err != nil {
+		t.Fatalf("failed to create rotating reader: %v", err)
+	}
+
+	var out basic
+	found, err := rr.GetRowByKey(context.Background(), &out, "family", "table", 1)
+	if err != nil || !found {
+		t.Errorf("failed to find key 0: %v", err)
+	}
+	require.Equal(t, 1, out.x)
+
+	reader := rr.(*LDBRotatingReader)
+
+	var out2 basic
+	reader.active.Store(1)
+	found, err = reader.GetRowByKey(context.Background(), &out2, "family", "table", 2)
+	if err != nil || !found {
+		t.Errorf("failed to find key 1: %v", err)
+	}
+	require.Equal(t, 2, out2.x)
+
+}
+
+func TestValidRotatingReader(t *testing.T) {
+	tests := []struct {
+		name   string
+		expErr string
+		paths  []string
+		rf     RotationFrequency
+	}{
+		{
+			"1 ldb",
+			"more than 1 ldb",
+			[]string{"1path"},
+			Every30,
+		},
+		{
+			"No ldb",
+			"more than 1 ldb",
+			[]string{},
+			Every30,
+		},
+		{
+			"Nil ldb",
+			"more than 1 ldb",
+			nil,
+			Every30,
+		},
+		{
+			"bad rotation",
+			"invalid rotation",
+			[]string{"path1", "path2"},
+			RotationFrequency(2),
+		},
+		{
+			"more ldbs than freq",
+			"cannot have more",
+			[]string{"path1", "path2", "path3", "path4", "path5", "path6", "path7"},
+			Every6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := rotatingReader(tt.rf, tt.paths...)
+			if err == nil {
+				t.Fatal("error expected, none found")
+			}
+
+			if !strings.Contains(err.Error(), tt.expErr) {
+				t.Error("Did not find right error")
+			}
+		})
+	}
+}
+
+func TestRotation(t *testing.T) {
+	_, paths := getMultiDBs(t, 6)
+
+	rr, err := rotatingReader(Every6, paths...)
+	if err != nil {
+		t.Fatal("unexpected error creating reader")
+	}
+
+	tests := []struct {
+		name    string
+		nowFunc func() time.Time
+		exp     int
+	}{
+		{
+			"0-5",
+			func() time.Time {
+				return time.Date(2023, 8, 17, 9, 1, 0, 0, time.UTC)
+			},
+			0,
+		},
+		{
+			"6-11",
+			func() time.Time {
+				return time.Date(2023, 8, 17, 9, 8, 0, 0, time.UTC)
+			},
+			1,
+		},
+		{
+			"12-17",
+			func() time.Time {
+				return time.Date(2023, 8, 17, 9, 17, 0, 0, time.UTC)
+			},
+			2,
+		},
+		{
+			"18-23",
+			func() time.Time {
+				return time.Date(2023, 8, 17, 9, 21, 0, 0, time.UTC)
+			},
+			3,
+		},
+		{
+			"24-29",
+			func() time.Time {
+				return time.Date(2023, 8, 17, 9, 24, 0, 0, time.UTC)
+			},
+			4,
+		},
+		{
+			"30-35",
+			func() time.Time {
+				return time.Date(2023, 8, 17, 9, 32, 0, 0, time.UTC)
+			},
+			5,
+		},
+		{
+			"36-41",
+			func() time.Time {
+				return time.Date(2023, 8, 17, 9, 41, 0, 0, time.UTC)
+			},
+			0,
+		},
+		{
+			"42-47",
+			func() time.Time {
+				return time.Date(2023, 8, 17, 9, 42, 0, 0, time.UTC)
+			},
+			1,
+		},
+		{
+			"48-53",
+			func() time.Time {
+				return time.Date(2023, 8, 17, 9, 53, 0, 0, time.UTC)
+			},
+			2,
+		},
+		{
+			"54-59",
+			func() time.Time {
+				return time.Date(2023, 8, 17, 9, 59, 0, 0, time.UTC)
+			},
+			3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr.now = tt.nowFunc
+			rr.setActive()
+			if rr.active.Load() != int32(tt.exp) {
+				t.Errorf("expected %d to be active, got %d instead", tt.exp, rr.active.Load())
+			}
+		})
+	}
+}
+
+func TestMultipleReaders(t *testing.T) {
+	ctx := context.Background()
+	dbs, paths := getMultiDBs(t, 4)
+
+	for i, db := range dbs {
+		_, err := db.Exec("CREATE TABLE family___foo (id varchar primary key );")
+		if err != nil {
+			t.Fatalf("failure creating table, %v", err)
+		}
+		_, err = db.Exec(fmt.Sprintf("INSERT INTO family___foo values ('%d');", i))
+		if err != nil {
+			t.Fatalf("failure inserting into table, %v", err)
+		}
+	}
+
+	rr, err := rotatingReader(Every15, paths...)
+	if err != nil {
+		t.Fatalf("unexpected error creating reader, %v", err)
+	}
+	i := 0
+	wait := make(chan interface{})
+
+	rr.now = func() time.Time {
+		defer func() {
+			if i != 0 {
+				wait <- 1
+			}
+			i = i + 15
+		}()
+		return time.Date(2023, 8, 17, 10, 0+i, 59, 999_999_999, time.UTC)
+	}
+	rr.tickerInterval = 1 * time.Millisecond
+	rr.setActive()
+	go rr.rotate(ctx)
+
+	for x := range dbs {
+		out := make(map[string]interface{})
+		val, err := rr.GetRowByKey(ctx, out, "family", "foo", x)
+		if err != nil || !val {
+			t.Errorf("unexpected error on GetRowByKey %v", err)
+		}
+
+		require.EqualValues(t, out, map[string]interface{}{"id": strconv.Itoa(x)}, "did not read correct value from table")
+
+		for y := range dbs {
+			if y == x {
+				continue
+			}
+			val, err = rr.GetRowByKey(ctx, out, "family", "foo", y)
+			if val || err != nil {
+				t.Errorf("row with key %d should not be found", y)
+			}
+		}
+
+		<-wait
+		time.Sleep(500 * time.Microsecond)
+	}
+
+}
+
+type kv struct {
+	id  string `ctlstore:"id"`
+	bar string `ctlstore:"bar"`
+}
+
+func TestGetRowByPrefixAfterRotation(t *testing.T) {
+	ctx := context.Background()
+	dbs, paths := getMultiDBs(t, 4)
+
+	for i, db := range dbs {
+		_, err := db.Exec("CREATE TABLE family___foo (id varchar, bar varchar, primary key (id, bar));")
+		if err != nil {
+			t.Fatalf("failure creating table, %v", err)
+		}
+		_, err = db.Exec(fmt.Sprintf("INSERT INTO family___foo values ('%d', '0'), ('%d', '1'), ('%d', '2'), ('%d', '3');", i, i, i, i))
+		if err != nil {
+			t.Fatalf("failure inserting into table, %v", err)
+		}
+	}
+
+	rr, err := rotatingReader(Every15, paths...)
+	if err != nil {
+		t.Fatalf("unexpected error creating reader, %v", err)
+	}
+
+	i := 0
+	wait := make(chan interface{})
+	rr.now = func() time.Time {
+		defer func() {
+			if i != 0 {
+				wait <- 1
+			}
+			i = i + 15
+		}()
+		return time.Date(2023, 8, 17, 10, (0+i)%60, 59, 999_999_999, time.UTC)
+	}
+	rr.tickerInterval = 1 * time.Millisecond
+	rr.setActive()
+	rows, err := rr.GetRowsByKeyPrefix(ctx, "family", "foo", "0")
+
+	go rr.rotate(ctx)
+
+	count := 0
+	for rows.Next() {
+		var tar kv
+		rows.Scan(&tar)
+		require.Equal(t, "0", tar.id)
+		require.Equal(t, strconv.Itoa(count), tar.bar)
+		<-wait
+		time.Sleep(500 * time.Microsecond)
+		var out kv
+		count++
+
+		// should rotate by now, check if different result set is returned
+		found, err := rr.GetRowByKey(ctx, &out, "family", "foo", "0", "0")
+		if count == 4 {
+			require.EqualValues(t, kv{"0", "0"}, out, "should have rotated all the way back to the first reader")
+		} else if found || err != nil {
+			t.Errorf("should not have found the key since it rotated: %v", err)
+		}
+	}
+
+	require.Equal(t, 4, count, "should've returned 4 rows")
+}

--- a/ldb_rotating_reader_test.go
+++ b/ldb_rotating_reader_test.go
@@ -45,7 +45,7 @@ func TestBasicRotatingReader(t *testing.T) {
 		}
 	}
 
-	rr, err := RotatingReader(context.Background(), Every30, paths...)
+	rr, err := CustomerRotatingReader(context.Background(), Every30, paths...)
 	if err != nil {
 		t.Fatalf("failed to create rotating reader: %v", err)
 	}
@@ -353,4 +353,21 @@ func TestGetRowByPrefixAfterRotation(t *testing.T) {
 	}
 
 	require.Equal(t, 4, count, "should've returned 4 rows")
+}
+
+func TestPath(t *testing.T) {
+	paths := defaultPaths(5)
+	if len(paths) != 5 {
+		t.Fatal("should be 5 paths")
+	}
+
+	if paths[0] != defaultPath {
+		t.Fatalf("First path should be the default, %s", paths[0])
+	}
+
+	for i := 1; i < 5; i++ {
+		if !strings.Contains(paths[i], strconv.Itoa(i)) {
+			t.Errorf("path %s should've contained its number, %d", paths[i], i)
+		}
+	}
 }

--- a/ldb_rotating_reader_test.go
+++ b/ldb_rotating_reader_test.go
@@ -74,7 +74,7 @@ func TestValidRotatingReader(t *testing.T) {
 		name   string
 		expErr string
 		paths  []string
-		rf     RotationFrequency
+		rp     RotationPeriod
 	}{
 		{
 			"1 ldb",
@@ -98,25 +98,31 @@ func TestValidRotatingReader(t *testing.T) {
 			"bad rotation",
 			"invalid rotation",
 			[]string{"path1", "path2"},
-			RotationFrequency(2),
+			RotationPeriod(2),
 		},
 		{
-			"more ldbs than freq",
+			"more ldbs than period, max",
 			"cannot have more",
-			[]string{"path1", "path2", "path3", "path4", "path5", "path6", "path7"},
+			[]string{"path1", "path2", "path3", "path4", "path5", "path6", "path7", "path8", "path9", "path10", "path11"},
 			Every6,
+		},
+		{
+			"more ldbs than period, min",
+			"cannot have more",
+			[]string{"path1", "path2", "path3"},
+			Every30,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := rotatingReader(tt.rf, tt.paths...)
+			_, err := rotatingReader(tt.rp, tt.paths...)
 			if err == nil {
 				t.Fatal("error expected, none found")
 			}
 
 			if !strings.Contains(err.Error(), tt.expErr) {
-				t.Error("Did not find right error")
+				t.Errorf("Did not find right error: got %v", err)
 			}
 		})
 	}

--- a/pkg/cmd/ctlstore/main.go
+++ b/pkg/cmd/ctlstore/main.go
@@ -545,7 +545,8 @@ func multiReflector(ctx context.Context, args []string) {
 	}
 
 	grp, grpCtx := errgroup.WithContext(ctx)
-	for _, r := range reflectors {
+	for _, reflector := range reflectors {
+		r := reflector
 		grp.Go(func() error {
 			return r.Start(grpCtx)
 		})

--- a/pkg/ldbwriter/ldb_writer.go
+++ b/pkg/ldbwriter/ldb_writer.go
@@ -256,12 +256,12 @@ func (w *SqlLdbWriter) Checkpoint(checkpointingType CheckpointType) (*PragmaWALR
 }
 
 func (w *SqlLdbWriter) log(format string, args ...interface{}) {
-	events.Log(format, argify(args, w.logArgs))
+	events.Log(format, argify(args, w.logArgs)...)
 }
 
 func (w *SqlLdbWriter) debug(format string, args ...interface{}) {
 	if events.DefaultLogger.EnableDebug {
-		events.Debug(format, argify(args, w.logArgs))
+		events.Debug(format, argify(args, w.logArgs)...)
 	}
 }
 

--- a/pkg/ldbwriter/ldb_writer.go
+++ b/pkg/ldbwriter/ldb_writer.go
@@ -38,41 +38,52 @@ type LDBWriteMetadata struct {
 type SqlLdbWriter struct {
 	Db       *sql.DB
 	LedgerTx *sql.Tx
+	// uniquely identify this SqlWriter
+	ID      string
+	logArgs events.Args
 }
 
 // Applies a DML statement to the writer's db, updating the sequence
 // tracking table in the same transaction
-func (writer *SqlLdbWriter) ApplyDMLStatement(_ context.Context, statement schema.DMLStatement) error {
+func (w *SqlLdbWriter) ApplyDMLStatement(_ context.Context, statement schema.DMLStatement) error {
 	var tx *sql.Tx
 	var err error
 
-	stats.Incr("sql_ldb_writer.apply")
+	stats.Incr("sql_ldb_writer.apply", stats.T("id", w.ID))
 
 	// Fill in the tx var
-	if writer.LedgerTx == nil {
+	if w.LedgerTx == nil {
 		// Not applying a ledger transaction, so need a local transaction
-		tx, err = writer.Db.Begin()
+		tx, err = w.Db.Begin()
 		if err != nil {
-			errs.Incr("sql_ldb_writer.begin_tx.error")
+			errs.Incr("sql_ldb_writer.begin_tx.error", stats.T("id", w.ID))
 			return errors.Wrap(err, "open tx error")
 		}
 	} else {
 		// Applying a ledger transaction, so bring it into scope
-		tx = writer.LedgerTx
+		tx = w.LedgerTx
+	}
+
+	if w.logArgs == nil {
+		if w.ID != "" {
+			w.logArgs = events.Args{{"id", w.ID}}
+		} else {
+			w.logArgs = events.Args{}
+		}
 	}
 
 	// Handle begin ledger transaction control statements
 	if statement.Statement == schema.DMLTxBeginKey {
-		if writer.LedgerTx != nil {
+		if w.LedgerTx != nil {
 			// Attempted to open a transaction without committing the last one,
 			// which is a violation of our invariants. Something is very, very
 			// wrong with the ledger processing.
 			tx.Rollback()
-			errs.Incr("sql_ldb_writer.ledgerTx.begin_invariant_violation")
+			errs.Incr("sql_ldb_writer.ledgerTx.begin_invariant_violation", stats.T("id", w.ID))
 			return errors.New("invariant violation")
 		}
-		writer.LedgerTx = tx
-		events.Debug("Begin TX at %{sequence}v", statement.Sequence)
+		w.LedgerTx = tx
+		w.debug("Begin TX at %{sequence}v", statement.Sequence)
 	}
 
 	// Update the last update table.  This will allow the ldb reader
@@ -84,7 +95,7 @@ func (writer *SqlLdbWriter) ApplyDMLStatement(_ context.Context, statement schem
 	_, err = tx.Exec(qs, ldb.LDBLastLedgerUpdateColumn, statement.Timestamp)
 	if err != nil {
 		tx.Rollback()
-		errs.Incr("sql_ldb_writer.upsert_last_update.error")
+		errs.Incr("sql_ldb_writer.upsert_last_update.error", stats.T("id", w.ID))
 		return errors.Wrap(err, "update last_update")
 	}
 
@@ -103,7 +114,7 @@ func (writer *SqlLdbWriter) ApplyDMLStatement(_ context.Context, statement schem
 	res, err := tx.Exec(qs, statement.Sequence.Int())
 	if err != nil {
 		tx.Rollback()
-		errs.Incr("sql_ldb_writer.upsert_seq.error")
+		errs.Incr("sql_ldb_writer.upsert_seq.error", stats.T("id", w.ID))
 		return errors.Wrap(err, "update seq tracker error")
 	}
 
@@ -111,12 +122,12 @@ func (writer *SqlLdbWriter) ApplyDMLStatement(_ context.Context, statement schem
 	rowsAffected, err := res.RowsAffected()
 	if err != nil {
 		tx.Rollback()
-		errs.Incr("sql_ldb_writer.upsert_seq.rows_affected_error")
+		errs.Incr("sql_ldb_writer.upsert_seq.rows_affected_error", stats.T("id", w.ID))
 		return errors.Wrap(err, "update seq tracker rows affected error")
 	}
 	if rowsAffected == 0 {
 		tx.Rollback()
-		errs.Incr("sql_ldb_writer.upsert_seq.replay_detected")
+		errs.Incr("sql_ldb_writer.upsert_seq.replay_detected", stats.T("id", w.ID))
 		return errors.New("update seq tracker replay detected")
 	}
 
@@ -130,27 +141,27 @@ func (writer *SqlLdbWriter) ApplyDMLStatement(_ context.Context, statement schem
 
 	// Handle end ledger transaction control statements
 	if statement.Statement == schema.DMLTxEndKey {
-		if writer.LedgerTx == nil {
+		if w.LedgerTx == nil {
 			// Attempted to commit a transaction when there is no transaction
 			// open, which is a violation of our invariants. Something is very,
 			// very wrong with the ledger processing!
 			tx.Rollback()
-			errs.Incr("sql_ldb_writer.ledgerTx.end_invariant_violation")
+			errs.Incr("sql_ldb_writer.ledgerTx.end_invariant_violation", stats.T("id", w.ID))
 			return errors.New("invariant violation")
 		}
 
 		err = tx.Commit()
 		if err != nil {
 			tx.Rollback()
-			errs.Incr("sql_ldb_writer.ledgerTx.commit.error")
-			events.Log("Failed to commit Tx at seq %{seq}s: %{error}+v",
+			errs.Incr("sql_ldb_writer.ledgerTx.commit.error", stats.T("id", w.ID))
+			w.log("Failed to commit Tx at seq %{seq}s: %{error}+v",
 				statement.Sequence,
 				err)
 			return errors.Wrap(err, "commit multi-statement dml tx error")
 		}
-		stats.Incr("sql_ldb_writer.ledgerTx.commit.success")
-		events.Debug("Committed TX at %{sequence}v", statement.Sequence)
-		writer.LedgerTx = nil
+		stats.Incr("sql_ldb_writer.ledgerTx.commit.success", stats.T("id", w.ID))
+		w.debug("Committed TX at %{sequence}v", statement.Sequence)
+		w.LedgerTx = nil
 		return nil
 	}
 
@@ -158,37 +169,37 @@ func (writer *SqlLdbWriter) ApplyDMLStatement(_ context.Context, statement schem
 	_, err = tx.Exec(statement.Statement)
 	if err != nil {
 		tx.Rollback()
-		errs.Incr("sql_ldb_writer.exec.error")
+		errs.Incr("sql_ldb_writer.exec.error", stats.T("id", w.ID))
 		return errors.Wrap(err, "exec dml statement error")
 	}
 
-	stats.Incr("sql_ldb_writer.exec.success")
+	stats.Incr("sql_ldb_writer.exec.success", stats.T("id", w.ID))
 
-	events.Debug("Applying DML[%{sequence}d]: '%{statement}s'",
+	w.debug("Applying DML[%{sequence}d]: '%{statement}s'",
 		statement.Sequence,
 		statement.Statement)
 
 	// Commit if not inside a ledger transaction, since that would be
 	// a single statement transaction.
-	if writer.LedgerTx == nil {
+	if w.LedgerTx == nil {
 		err = tx.Commit()
 		if err != nil {
 			tx.Rollback()
-			errs.Incr("sql_ldb_writer.single.commit.error")
-			errs.Incr("sql_ldb_writer.commit.error")
+			errs.Incr("sql_ldb_writer.single.commit.error", stats.T("id", w.ID))
+			errs.Incr("sql_ldb_writer.commit.error", stats.T("id", w.ID))
 			return errors.Wrap(err, "commit one-statement dml tx error")
 		}
 	}
 
-	stats.Incr("sql_ldb_writer.commit.success")
+	stats.Incr("sql_ldb_writer.commit.success", stats.T("id", w.ID))
 
 	return nil
 }
 
-func (writer *SqlLdbWriter) Close() error {
-	if writer.LedgerTx != nil {
-		writer.LedgerTx.Rollback()
-		writer.LedgerTx = nil
+func (w *SqlLdbWriter) Close() error {
+	if w.LedgerTx != nil {
+		w.LedgerTx.Rollback()
+		w.LedgerTx = nil
 	}
 	return nil
 }
@@ -222,11 +233,11 @@ var (
 // Checkpoint initiates a wal checkpoint, returning stats on the checkpoint's progress
 // see https://www.sqlite.org/pragma.html#pragma_wal_checkpoint for more details
 // requires write access
-func (writer *SqlLdbWriter) Checkpoint(checkpointingType CheckpointType) (*PragmaWALResult, error) {
-	res, err := writer.Db.Query(fmt.Sprintf("PRAGMA wal_checkpoint(%s)", string(checkpointingType)))
+func (w *SqlLdbWriter) Checkpoint(checkpointingType CheckpointType) (*PragmaWALResult, error) {
+	res, err := w.Db.Query(fmt.Sprintf("PRAGMA wal_checkpoint(%s)", string(checkpointingType)))
 	if err != nil {
-		events.Log("error in checkpointing, %{error}", err)
-		errs.Incr("sql_ldb_writer.wal_checkpoint.query.error")
+		w.log("error in checkpointing, %{error}", err)
+		errs.Incr("sql_ldb_writer.wal_checkpoint.query.error", stats.T("id", w.ID))
 		return nil, err
 	}
 
@@ -235,11 +246,34 @@ func (writer *SqlLdbWriter) Checkpoint(checkpointingType CheckpointType) (*Pragm
 	if res.Next() {
 		err := res.Scan(&p.Busy, &p.Log, &p.Checkpointed)
 		if err != nil {
-			events.Log("error in scanning checkpointing, %{error}", err)
-			errs.Incr("sql_ldb_writer.wal_checkpoint.scan.error")
+			w.log("error in scanning checkpointing, %{error}")
+			errs.Incr("sql_ldb_writer.wal_checkpoint.scan.error", stats.T("id", w.ID))
 			return nil, err
 		}
 	}
 	p.Type = checkpointingType
 	return &p, nil
+}
+
+func (w *SqlLdbWriter) log(format string, args ...interface{}) {
+	events.Log(format, argify(args, w.logArgs))
+}
+
+func (w *SqlLdbWriter) debug(format string, args ...interface{}) {
+	if events.DefaultLogger.EnableDebug {
+		events.Debug(format, argify(args, w.logArgs))
+	}
+}
+
+func argify(args []interface{}, logArgs interface{}) []interface{} {
+	if args == nil && logArgs == nil {
+		return nil
+	}
+	if args == nil {
+		return []interface{}{logArgs}
+	}
+	if logArgs == nil {
+		return args
+	}
+	return append(args, logArgs)
 }

--- a/pkg/ldbwriter/ldb_writer_test.go
+++ b/pkg/ldbwriter/ldb_writer_test.go
@@ -357,6 +357,9 @@ func TestCheckpointQuery(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(string(tt.cpType), func(t *testing.T) {
 			res, err := writer.Checkpoint(tt.cpType)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
 			err = writer.ApplyDMLStatement(context.Background(), schema.NewTestDMLStatement("INSERT INTO foo VALUES('hello');"))
 			if err != nil {
 				t.Fatalf("expected no error, got %v", err)

--- a/pkg/reflector/reflector.go
+++ b/pkg/reflector/reflector.go
@@ -479,5 +479,5 @@ type noopStarter struct {
 func (n *noopStarter) Start(ctx context.Context) {}
 
 func (r *Reflector) log(format string, args ...interface{}) {
-	events.Log(format, argify(args, r.logArgs))
+	events.Log(format, argify(args, r.logArgs)...)
 }

--- a/pkg/reflector/reflector.go
+++ b/pkg/reflector/reflector.go
@@ -291,6 +291,7 @@ func ReflectorFromConfig(config ReflectorConfig) (*Reflector, error) {
 }
 
 func (r *Reflector) Start(ctx context.Context) error {
+
 	r.logger.Log("Starting Reflector.")
 	go r.ledgerMonitor.Start(ctx)
 	go r.walMonitor.Start(ctx)

--- a/pkg/reflector/reflector_test.go
+++ b/pkg/reflector/reflector_test.go
@@ -64,6 +64,7 @@ func TestShovelSequenceReset(t *testing.T) {
 		LedgerHealth: ledger.HealthConfig{
 			DisableECSBehavior: true,
 		},
+		Logger: events.DefaultLogger,
 	}
 	reflector, err := ReflectorFromConfig(cfg)
 	require.NoError(t, err)
@@ -153,6 +154,7 @@ func TestReflector(t *testing.T) {
 			DisableECSBehavior: true,
 			PollInterval:       10 * time.Second,
 		},
+		Logger: events.DefaultLogger,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/pkg/reflector/shovel.go
+++ b/pkg/reflector/shovel.go
@@ -23,7 +23,7 @@ type shovel struct {
 	abortOnSeqSkip    bool
 	maxSeqOnStartup   int64
 	stop              chan struct{}
-	logArgs           events.Args
+	log               *events.Logger
 }
 
 func (s *shovel) Start(ctx context.Context) error {
@@ -45,7 +45,7 @@ func (s *shovel) Start(ctx context.Context) error {
 		// early exit here if the shovel should be stopped
 		select {
 		case <-s.stop:
-			s.log("Shovel stopping normally")
+			s.logger().Log("Shovel stopping normally")
 			return nil
 		default:
 		}
@@ -57,7 +57,7 @@ func (s *shovel) Start(ctx context.Context) error {
 		sctx, cancel = context.WithTimeout(ctx, s.pollTimeout)
 
 		stats.Incr("shovel.loop_enter")
-		s.debug("shovel polling...")
+		s.logger().Debug("shovel polling...")
 		st, err := s.source.Next(sctx)
 
 		if err != nil {
@@ -79,7 +79,7 @@ func (s *shovel) Start(ctx context.Context) error {
 			//
 
 			pollSleep := jitr.Jitter(s.pollInterval, s.jitterCoefficient)
-			s.debug("Poll sleep %{sleepTime}s", pollSleep)
+			s.logger().Debug("Poll sleep %{sleepTime}s", pollSleep)
 
 			select {
 			case <-ctx.Done():
@@ -91,12 +91,12 @@ func (s *shovel) Start(ctx context.Context) error {
 			continue
 		}
 
-		s.debug("Shovel applying %{statement}v", st)
+		s.logger().Debug("Shovel applying %{statement}v", st)
 
 		if lastSeq != 0 {
 			if st.Sequence > lastSeq+1 && st.Sequence.Int() > s.maxSeqOnStartup {
 				stats.Incr("shovel.skipped_sequence")
-				s.log("shovel skip sequence from:%{fromSeq}d to:%{toSeq}d", lastSeq, st.Sequence)
+				s.logger().Log("shovel skip sequence from:%{fromSeq}d to:%{toSeq}d", lastSeq, st.Sequence)
 
 				if s.abortOnSeqSkip {
 					// Mitigation for a bug that we haven't found yet
@@ -133,31 +133,15 @@ func (s *shovel) Close() error {
 	for _, closer := range s.closers {
 		err := closer.Close()
 		if err != nil {
-			s.log("shovel encountered error during close: %{error}s", err)
+			s.logger().Log("shovel encountered error during close: %{error}s", err)
 		}
 	}
 	return nil
 }
 
-func (s *shovel) log(format string, args ...interface{}) {
-	events.Log(format, argify(args, s.logArgs)...)
-}
-
-func argify(args []interface{}, logArgs interface{}) []interface{} {
-	if args == nil && logArgs == nil {
-		return nil
+func (s *shovel) logger() *events.Logger {
+	if s.log == nil {
+		s.log = events.DefaultLogger
 	}
-	if args == nil {
-		return []interface{}{logArgs}
-	}
-	if logArgs == nil {
-		return args
-	}
-	return append(args, logArgs)
-}
-
-func (s *shovel) debug(format string, args ...interface{}) {
-	if events.DefaultLogger.EnableDebug {
-		events.Debug(format, argify(args, s.logArgs)...)
-	}
+	return s.log
 }

--- a/pkg/reflector/shovel.go
+++ b/pkg/reflector/shovel.go
@@ -23,6 +23,7 @@ type shovel struct {
 	abortOnSeqSkip    bool
 	maxSeqOnStartup   int64
 	stop              chan struct{}
+	logArgs           events.Args
 }
 
 func (s *shovel) Start(ctx context.Context) error {
@@ -44,7 +45,7 @@ func (s *shovel) Start(ctx context.Context) error {
 		// early exit here if the shovel should be stopped
 		select {
 		case <-s.stop:
-			events.Log("Shovel stopping normally")
+			s.log("Shovel stopping normally")
 			return nil
 		default:
 		}
@@ -56,7 +57,7 @@ func (s *shovel) Start(ctx context.Context) error {
 		sctx, cancel = context.WithTimeout(ctx, s.pollTimeout)
 
 		stats.Incr("shovel.loop_enter")
-		events.Debug("shovel polling...")
+		s.debug("shovel polling...")
 		st, err := s.source.Next(sctx)
 
 		if err != nil {
@@ -78,7 +79,7 @@ func (s *shovel) Start(ctx context.Context) error {
 			//
 
 			pollSleep := jitr.Jitter(s.pollInterval, s.jitterCoefficient)
-			events.Debug("Poll sleep %{sleepTime}s", pollSleep)
+			s.debug("Poll sleep %{sleepTime}s", pollSleep)
 
 			select {
 			case <-ctx.Done():
@@ -90,12 +91,12 @@ func (s *shovel) Start(ctx context.Context) error {
 			continue
 		}
 
-		events.Debug("Shovel applying %{statement}v", st)
+		s.debug("Shovel applying %{statement}v", st)
 
 		if lastSeq != 0 {
 			if st.Sequence > lastSeq+1 && st.Sequence.Int() > s.maxSeqOnStartup {
 				stats.Incr("shovel.skipped_sequence")
-				events.Log("shovel skip sequence from:%{fromSeq}d to:%{toSeq}d", lastSeq, st.Sequence)
+				s.log("shovel skip sequence from:%{fromSeq}d to:%{toSeq}d", lastSeq, st.Sequence)
 
 				if s.abortOnSeqSkip {
 					// Mitigation for a bug that we haven't found yet
@@ -132,8 +133,31 @@ func (s *shovel) Close() error {
 	for _, closer := range s.closers {
 		err := closer.Close()
 		if err != nil {
-			events.Log("shovel encountered error during close: %{error}s", err)
+			s.log("shovel encountered error during close: %{error}s", err)
 		}
 	}
 	return nil
+}
+
+func (s *shovel) log(format string, args ...interface{}) {
+	events.Log(format, argify(args, s.logArgs)...)
+}
+
+func argify(args []interface{}, logArgs interface{}) []interface{} {
+	if args == nil && logArgs == nil {
+		return nil
+	}
+	if args == nil {
+		return []interface{}{logArgs}
+	}
+	if logArgs == nil {
+		return args
+	}
+	return append(args, logArgs)
+}
+
+func (s *shovel) debug(format string, args ...interface{}) {
+	if events.DefaultLogger.EnableDebug {
+		events.Debug(format, argify(args, s.logArgs)...)
+	}
 }

--- a/pkg/reflector/shovel_test.go
+++ b/pkg/reflector/shovel_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"github.com/segmentio/ctlstore/pkg/ldbwriter"
+	"github.com/segmentio/ctlstore/pkg/schema"
+	"github.com/segmentio/events/v2"
 	"reflect"
 	"testing"
 	"time"
-
-	"github.com/segmentio/ctlstore/pkg/ldbwriter"
-	"github.com/segmentio/ctlstore/pkg/schema"
 )
 
 // I totally overdid this test suite. I don't even know why.
@@ -26,6 +26,7 @@ type shovelTest struct {
 	check        func(*shovelTestContext)
 	expectErr    error
 	timeout      time.Duration
+	logArgs      events.Args
 }
 
 type shovelTestContext struct {
@@ -136,6 +137,7 @@ func TestShovel(t *testing.T) {
 				tcx.mockSource.returnErr = errTest
 			},
 			expectErr: errTest,
+			logArgs:   events.Args{{"test", "value"}},
 		},
 		{
 			desc:         "Polls at the specified interval",
@@ -200,6 +202,7 @@ func TestShovel(t *testing.T) {
 				}
 			},
 			expectErr: context.DeadlineExceeded,
+			logArgs:   events.Args{{"test", "value"}},
 		},
 	}
 
@@ -219,6 +222,7 @@ func TestShovel(t *testing.T) {
 				writer:       t1.writer,
 				pollInterval: t1.pollInterval,
 				pollTimeout:  pollTimeout,
+				logArgs:      t1.logArgs,
 			}
 
 			stctx := shovelTestContext{

--- a/pkg/reflector/shovel_test.go
+++ b/pkg/reflector/shovel_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"github.com/segmentio/ctlstore/pkg/ldbwriter"
 	"github.com/segmentio/ctlstore/pkg/schema"
-	"github.com/segmentio/events/v2"
 	"reflect"
 	"testing"
 	"time"
@@ -26,7 +25,6 @@ type shovelTest struct {
 	check        func(*shovelTestContext)
 	expectErr    error
 	timeout      time.Duration
-	logArgs      events.Args
 }
 
 type shovelTestContext struct {
@@ -137,7 +135,6 @@ func TestShovel(t *testing.T) {
 				tcx.mockSource.returnErr = errTest
 			},
 			expectErr: errTest,
-			logArgs:   events.Args{{"test", "value"}},
 		},
 		{
 			desc:         "Polls at the specified interval",
@@ -202,7 +199,6 @@ func TestShovel(t *testing.T) {
 				}
 			},
 			expectErr: context.DeadlineExceeded,
-			logArgs:   events.Args{{"test", "value"}},
 		},
 	}
 
@@ -222,7 +218,6 @@ func TestShovel(t *testing.T) {
 				writer:       t1.writer,
 				pollInterval: t1.pollInterval,
 				pollTimeout:  pollTimeout,
-				logArgs:      t1.logArgs,
 			}
 
 			stctx := shovelTestContext{

--- a/pkg/reflector/wal_monitor.go
+++ b/pkg/reflector/wal_monitor.go
@@ -3,6 +3,7 @@ package reflector
 import (
 	"context"
 	"os"
+	"path"
 	"time"
 
 	"github.com/segmentio/events/v2"
@@ -116,9 +117,10 @@ func (m *WALMonitor) Start(ctx context.Context) {
 		if res.Busy == 1 {
 			isBusy = "true"
 		}
-		stats.Set("wal-checkpoint-status", 1, stats.T("busy", isBusy))
-		stats.Set("wal-total-pages", res.Log)
-		stats.Set("wal-checkpointed-pages", res.Checkpointed)
+		ldbFileName := path.Base(m.walPath)
+		stats.Set("wal-checkpoint-status", 1, stats.T("busy", isBusy), stats.T("ldb", ldbFileName))
+		stats.Set("wal-total-pages", res.Log, stats.T("ldb", ldbFileName))
+		stats.Set("wal-checkpointed-pages", res.Checkpointed, stats.T("ldb", ldbFileName))
 
 		failedInARow = 0
 	})

--- a/pkg/reflector/wal_monitor.go
+++ b/pkg/reflector/wal_monitor.go
@@ -94,7 +94,9 @@ func (m *WALMonitor) Start(ctx context.Context) {
 			}
 			return
 		}
-		stats.Set("wal-file-size", size)
+
+		ldbFileName := path.Base(m.walPath)
+		stats.Set("wal-file-size", size, stats.T("ldb", ldbFileName))
 
 		if size <= m.walCheckpointThresholdSize {
 			stats.Incr("wal-no-checkpoint")
@@ -117,7 +119,6 @@ func (m *WALMonitor) Start(ctx context.Context) {
 		if res.Busy == 1 {
 			isBusy = "true"
 		}
-		ldbFileName := path.Base(m.walPath)
 		stats.Set("wal-checkpoint-status", 1, stats.T("busy", isBusy), stats.T("ldb", ldbFileName))
 		stats.Set("wal-total-pages", res.Log, stats.T("ldb", ldbFileName))
 		stats.Set("wal-checkpointed-pages", res.Checkpointed, stats.T("ldb", ldbFileName))

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -6,7 +6,6 @@ CTLSTORE_BOOTSTRAP_URL=$1
 CONCURRENCY=${2:-20}
 NUM_LDB=${3:-1}
 
-TAGS="downloaded:false"
 START=$(date +%s)
 END=$(date +%s)
 
@@ -18,14 +17,20 @@ if [ ! -f /var/spool/ctlstore/ldb.db ]; then
   START=$(date +%s)
   s5cmd -r 0 --log debug cp --concurrency $CONCURRENCY $CTLSTORE_BOOTSTRAP_URL .
 
-  TAGS="downloaded:true"
   if [[ ${CTLSTORE_BOOTSTRAP_URL: -2} == gz ]]; then
     echo "Decompressing"
     pigz -d snapshot.db.gz
-    TAGS="$TAGS,compressed:true"
   fi
 
-  TAGS="$TAGS,concurrency:$CONCURRENCY"
+  i=2
+  while [ "$i" -le $NUM_LDB ]; do
+    if [ ! -f  ldb-$i.db ]; then
+      echo "creating copy ldb-$i.db"
+      cp snapshot.db ldb-$i.db
+    fi
+    i=$(( i + 1 ))
+  done
+
   mv snapshot.db ldb.db
   END=$(date +%s)
   echo "ldb.db ready in $(($END - $START)) seconds"
@@ -33,11 +38,27 @@ else
   echo "Snapshot already present"
 fi
 
+# on existing nodes, we may already have the ldb file.
+# We should download a new snapshot to avoid copying an in-use ldb.db file and risking a malformed db
 i=2
 while [ "$i" -le $NUM_LDB ]; do
+
+  # make sure it's not already downloaded
   if [ ! -f  ldb-$i.db ]; then
+
+    # download the snapshot if it's not present
+    if [ ! -f /var/spool/ctlstore/snapshot.db ]; then
+      echo "Downloading a new snapshot for ldb copies"
+      s5cmd -r 0 --log debug cp --concurrency $CONCURRENCY $CTLSTORE_BOOTSTRAP_URL .
+    fi
+
     echo "creating copy ldb-$i.db"
-    cp ldb.db ldb-$i.db
+    cp snapshot.db ldb-$i.db
   fi
   i=$(( i + 1 ))
 done
+
+if [ -f /var/spool/ctlstore/snapshot.db ]; then
+  echo "removing snapshot.db"
+  rm snapshot.db
+fi

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -35,7 +35,9 @@ fi
 
 i=2
 while [ "$i" -le $NUM_LDB ]; do
-    echo "creating copy $i"
+  if [ ! -f  ldb-$i.db ]; then
+    echo "creating copy ldb-$i.db"
     cp ldb.db ldb-$i.db
-    i=$(( i + 1 ))
+  fi
+  i=$(( i + 1 ))
 done


### PR DESCRIPTION
This adds two new capabilities to ctlstore:

1. The ability to run multiple reflectors within a process using the `multi-reflector` command. 
    1. Each reflector runs independently of the others. If any fail, the whole process stops.
2. The ability to configure a reader client to use multiple LDBs at once with the `LDBRotatingReader` type. In its basic usage, the client configures itself to use 2 ldbs on a 30 minute schedule. This means minutes 0-29, the 1st ldb is used by all clients. During 30-59, the 2nd ldb is used by all clients. 

When you combine 1 and 2, you get nodes that maintain 2+ ldbs and clients that rotate in lockstep from each ldb. The advantage is that all clients read from a particular ldb at once, while the other ldbs are able to successfully checkpoint.

The major cons:
- multiple copies of the same LDB. In prod this is 8 GB x 2 = 16 GB. While large, compared to the runaway WAL file size (>20GB + the 8 GB ldb), this is acceptable.
- each of the reflectors opens a connection to the upstream db. In segment's case, the upstream db has plenty of CPU, memory and connection bandwidth to handle multiples of the special case.
  - if we later determine this isn't acceptable, we can implement a single source poller that feeds the `n` ldbs.


 Tested successfully in stage using integrations-consumer and prod using argus: https://github.com/segmentio/integrations-consumer/pull/292/files