### PR TITLE
properly check errors while shoveling

### DIFF
--- a/pkg/cmd/ctlstore/main.go
+++ b/pkg/cmd/ctlstore/main.go
@@ -57,6 +57,7 @@ type reflectorCliConfig struct {
 	BootstrapRegion            string                   `conf:"bootstrap-region" help:"If specified, indicates which region in which the S3 bucket lives"`
 	PollInterval               time.Duration            `conf:"poll-interval" help:"How often to pull the upstream" validate:"nonzero"`
 	PollJitterCoefficient      float64                  `conf:"poll-jitter-coefficient" help:"Coefficient for poll jittering"`
+	PollTimeout                time.Duration            `conf:"poll-timeout" help:"How long to poll from the source before canceling"`
 	QueryBlockSize             int                      `conf:"query-block-size" help:"Number of ledger entries to get at once"`
 	Debug                      bool                     `conf:"debug" help:"Turns on debug logging"`
 	LedgerHealth               ledgerHealthConfig       `conf:"ledger-latency" help:"Configure ledger latency behavior"`
@@ -483,6 +484,7 @@ func defaultReflectorCLIConfig(isSupervisor bool) reflectorCliConfig {
 		PollJitterCoefficient: 0.25,
 		QueryBlockSize:        100,
 		Dogstatsd:             defaultDogstatsdConfig(),
+		PollTimeout:           5 * time.Second,
 		LedgerHealth: ledgerHealthConfig{
 			Disable:                 false,
 			MaxHealthyLatency:       time.Minute,
@@ -552,7 +554,7 @@ func newReflector(cliCfg reflectorCliConfig, isSupervisor bool) (*reflectorpkg.R
 			PollInterval:          cliCfg.PollInterval,
 			PollJitterCoefficient: cliCfg.PollJitterCoefficient,
 			QueryBlockSize:        cliCfg.QueryBlockSize,
-			PollTimeout:           5 * time.Second,
+			PollTimeout:           cliCfg.PollTimeout,
 		},
 		WALPollInterval:            cliCfg.WALPollInterval,
 		DoMonitorWAL:               cliCfg.WALPollInterval > 0,

--- a/pkg/reflector/reflector_test.go
+++ b/pkg/reflector/reflector_test.go
@@ -224,7 +224,7 @@ func TestReflector(t *testing.T) {
 }
 
 func TestEmitMetricFromFile(t *testing.T) {
-	for _, test := range []struct {
+	for _, tt := range []struct {
 		name     string
 		fileName string
 		extra    string
@@ -273,6 +273,7 @@ func TestEmitMetricFromFile(t *testing.T) {
 			nil,
 		},
 	} {
+		test := tt
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			tempdir := t.TempDir()

--- a/pkg/reflector/shovel.go
+++ b/pkg/reflector/shovel.go
@@ -60,11 +60,12 @@ func (s *shovel) Start(ctx context.Context) error {
 		st, err := s.source.Next(sctx)
 
 		if err != nil {
-			if err != context.DeadlineExceeded && err != errNoNewStatements {
+			causeErr := errors.Cause(err)
+			if causeErr != context.DeadlineExceeded && causeErr != errNoNewStatements {
 				return err
 			}
 
-			if err == context.DeadlineExceeded {
+			if causeErr == context.DeadlineExceeded {
 				errs.Incr("shovel.deadline_exceeded")
 			}
 


### PR DESCRIPTION
When reading from the DML source during shoveling, the source can return an error under certain conditions. One of those is a timeout from reading the upstream source (ctldb). In that situation, we don’t want to kill the shoveling altogether since its recoverable with a bit of jitter and retry backoff. The existing code attempts to do this: https://github.com/segmentio/ctlstore/blob/master/pkg/reflector/shovel.go#L63-L69

Unfortunately, in the dml_source.go, we wrap all errors before returning them ie https://github.com/segmentio/ctlstore/blob/master/pkg/reflector/dml_source.go#L109. This means a direct equality check will never succeed. 

We should use errors.Cause() to get the underlying error. In this case, the timeout.

The existing test suite actually has a test case that fails due to the wrapping, but unfortunately never ran due to running the tests in parallel without creating a copy of the test on the stack before executing, ensuring that only the last test was run several times.

Testing completed successfully by deploying a build in stage that triggers a deadline exceeded scenario and verifying the err is properly handled and does not cause a reflector restart.