### PR TITLE
Add ability to get filtered next event from changelog

### DIFF
--- a/pkg/event/changelog.go
+++ b/pkg/event/changelog.go
@@ -107,7 +107,6 @@ func (c *fileChangelog) start(ctx context.Context) error {
 				// we are also watching the parent dir of the changelog in order
 				// to correctly detect file rotation.
 				if event.Name == c.path {
-					events.Debug("FS event: %{op}s", event)
 					select {
 					case fsNotifyCh <- event:
 					case <-ctx.Done():
@@ -160,7 +159,6 @@ func (c *fileChangelog) read(ctx context.Context, fsNotifyCh chan fsnotify.Event
 					return
 				}
 				event := entry.event()
-				events.Debug("Read sequence %{seq}d", event.Sequence)
 				c.send(ctx, eventErr{event: event})
 			}
 
@@ -198,7 +196,6 @@ func (c *fileChangelog) read(ctx context.Context, fsNotifyCh chan fsnotify.Event
 				if err != io.EOF {
 					return errors.Wrap(err, "read bytes")
 				}
-				events.Debug("EOF. Waiting for more content...")
 				select {
 				case <-time.After(time.Second):
 					events.Debug("Manually checking log")
@@ -211,7 +208,6 @@ func (c *fileChangelog) read(ctx context.Context, fsNotifyCh chan fsnotify.Event
 				case event := <-fsNotifyCh:
 					switch event.Op {
 					case fsnotify.Write:
-						events.Debug("Update detected")
 						continue
 					case fsnotify.Create:
 						events.Debug("New changelog created. Consuming the rest of current one...")

--- a/pkg/event/iterator.go
+++ b/pkg/event/iterator.go
@@ -17,7 +17,12 @@ type (
 		cancelFunc context.CancelFunc // used to shut down the changelog
 		previous   *Event             // the previous event we read
 	}
-	IteratorOpt func(i *Iterator)
+	IteratorOpt      func(i *Iterator)
+	FilteredIterator struct {
+		iterator *Iterator
+		family   string
+		table    string
+	}
 )
 
 var (
@@ -73,19 +78,49 @@ func (i *Iterator) Next(ctx context.Context) (event Event, err error) {
 	return event, err
 }
 
-// NextForFamilyTable blocks and returns the next event that matches the specified family and table
-func (i *Iterator) NextForFamilyTable(ctx context.Context, family, table string) (event Event, err error) {
+func (i *Iterator) Close() error {
+	i.cancelFunc() // shut down the changelog
+	return nil
+}
+
+// NewFilteredIterator returns a new iterator that looks for changes to the specified family
+// and table in the background and then exposes those changes through the Next method.
+// Make sure to Close() the iterator when you are done using it.
+//
+// If ErrOutOfSync is returned, that means that the iterator likely could not keep
+// up with the changelog. Please invalidate any caches dependent on this iterator.
+//
+// If a different error is returned, it's not really known at this time the best way
+// to deal with it.  It's possible that it could be a change in the changelog json
+// schema, or something more temporary.  Best response for now will be to log and instrument
+// the error, and then just invalidate the cache the same way you would with ErrOutOfSync.
+// As time goes on, we'll know a little bit better how to operate this under real-world
+// conditions.
+func NewFilteredIterator(ctx context.Context, changelogPath, family, table string, opts IteratorOpt) (*FilteredIterator, error) {
+	iter, err := NewIterator(ctx, changelogPath, opts)
+	if err != nil {
+		return nil, err
+	}
+	fi := &FilteredIterator{
+		iterator: iter,
+		family:   family,
+		table:    table,
+	}
+	return fi, nil
+}
+
+// Next blocks and returns the next event that matches the specified family and table
+func (i *FilteredIterator) Next(ctx context.Context) (event Event, err error) {
 	for {
-		event, err = i.Next(ctx)
+		event, err = i.iterator.Next(ctx)
 		if err != nil ||
-			(strings.EqualFold(event.RowUpdate.FamilyName, family) && strings.EqualFold(event.RowUpdate.TableName, table)) {
+			(strings.EqualFold(event.RowUpdate.FamilyName, i.family) && strings.EqualFold(event.RowUpdate.TableName, i.table)) {
 			break
 		}
 	}
 	return event, err
 }
 
-func (i *Iterator) Close() error {
-	i.cancelFunc() // shut down the changelog
-	return nil
+func (i *FilteredIterator) Close() error {
+	return i.iterator.Close()
 }

--- a/pkg/event/iterator.go
+++ b/pkg/event/iterator.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"context"
+	"strings"
 
 	"github.com/segmentio/errors-go"
 )
@@ -69,7 +70,19 @@ func (i *Iterator) Next(ctx context.Context) (event Event, err error) {
 			return event, ErrOutOfSync
 		}
 	}
-	return
+	return event, err
+}
+
+// NextForFamilyTable blocks and returns the next event that matches the specified family and table
+func (i *Iterator) NextForFamilyTable(ctx context.Context, family, table string) (event Event, err error) {
+	for {
+		event, err = i.Next(ctx)
+		if err != nil ||
+			(strings.EqualFold(event.RowUpdate.FamilyName, family) && strings.EqualFold(event.RowUpdate.TableName, table)) {
+			break
+		}
+	}
+	return event, err
 }
 
 func (i *Iterator) Close() error {


### PR DESCRIPTION
Added new method to Iterator, similar to Next but adds the ability to only return events for family/table user cares about. 

Also cut out some verbose logging from the changelog.

Testing completed successfully via unit tests