### PR TITLE
Upgrade go-sqlite3 to v1.14.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/segmentio/conf v1.1.0
 	github.com/segmentio/errors-go v1.0.0
 	github.com/segmentio/events/v2 v2.3.2
-	github.com/segmentio/go-sqlite3 v1.12.0
+	github.com/segmentio/go-sqlite3 v1.14.23-0.20240215094832-276ee774daea
 	github.com/segmentio/stats/v4 v4.6.2
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/sync v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/segmentio/go-snakecase v1.1.0 h1:ZJO4SNKKV0MjGOv0LHnixxN5FYv1JKBnVXEu
 github.com/segmentio/go-snakecase v1.1.0/go.mod h1:jk1miR5MS7Na32PZUykG89Arm+1BUSYhuGR6b7+hJto=
 github.com/segmentio/go-sqlite3 v1.12.0 h1:NG3Hdja6V/dDz1uYCapBJCobL+nQLwn6b8Z28DLOU0s=
 github.com/segmentio/go-sqlite3 v1.12.0/go.mod h1:ARXycbQZSoCAgThy5syFIL2aXbrKF3tE1DEHfOkxh1g=
+github.com/segmentio/go-sqlite3 v1.14.23-0.20240215094832-276ee774daea h1:sWvKzuWMmEgMs2FNV16o+Qnhzem19yoELBdguei3HC0=
+github.com/segmentio/go-sqlite3 v1.14.23-0.20240215094832-276ee774daea/go.mod h1:XD2URsGK8aqqwao9zj/8f/OuOEiFWP45GguwGM906mc=
 github.com/segmentio/objconv v1.0.1 h1:QjfLzwriJj40JibCV3MGSEiAoXixbp4ybhwfTB8RXOM=
 github.com/segmentio/objconv v1.0.1/go.mod h1:auayaH5k3137Cl4SoXTgrzQcuQDmvuVtZgS0fb1Ahys=
 github.com/segmentio/stats/v4 v4.6.2 h1:++YfKPTOPTZxE1DvavnpeBvB3hlDIm7IM+ULFzbCxCU=


### PR DESCRIPTION
This depends on https://github.com/segmentio/go-sqlite3/pull/9

Once that is merged, recreate the [segment-v1.14.22](https://github.com/segmentio/go-sqlite3/releases/tag/segment-v1.14.22) tag in that repo.

Testing completed successfully: ensure CI runs, verify on other services that include ctlstore, when those services are updated. https://segment.atlassian.net/browse/IO-1695