### PR TITLE
Upgrade go-sqlite3 to v1.14.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/segmentio/conf v1.1.0
 	github.com/segmentio/errors-go v1.0.0
 	github.com/segmentio/events/v2 v2.3.2
-	github.com/segmentio/go-sqlite3 v1.12.0
+	github.com/segmentio/go-sqlite3 v1.14.22-segment
 	github.com/segmentio/stats/v4 v4.6.2
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/sync v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/segmentio/go-snakecase v1.1.0 h1:ZJO4SNKKV0MjGOv0LHnixxN5FYv1JKBnVXEu
 github.com/segmentio/go-snakecase v1.1.0/go.mod h1:jk1miR5MS7Na32PZUykG89Arm+1BUSYhuGR6b7+hJto=
 github.com/segmentio/go-sqlite3 v1.12.0 h1:NG3Hdja6V/dDz1uYCapBJCobL+nQLwn6b8Z28DLOU0s=
 github.com/segmentio/go-sqlite3 v1.12.0/go.mod h1:ARXycbQZSoCAgThy5syFIL2aXbrKF3tE1DEHfOkxh1g=
+github.com/segmentio/go-sqlite3 v1.14.22-segment h1:CMV8jocJ3GqK5ALeFatw5lXANJpusyGAbLMmRWGb61I=
+github.com/segmentio/go-sqlite3 v1.14.22-segment/go.mod h1:XD2URsGK8aqqwao9zj/8f/OuOEiFWP45GguwGM906mc=
 github.com/segmentio/objconv v1.0.1 h1:QjfLzwriJj40JibCV3MGSEiAoXixbp4ybhwfTB8RXOM=
 github.com/segmentio/objconv v1.0.1/go.mod h1:auayaH5k3137Cl4SoXTgrzQcuQDmvuVtZgS0fb1Ahys=
 github.com/segmentio/stats/v4 v4.6.2 h1:++YfKPTOPTZxE1DvavnpeBvB3hlDIm7IM+ULFzbCxCU=


### PR DESCRIPTION
## Description

Update the `go-sqlite3` dependency for Ctlstore to get to the latest upstream version from https://github.com/mattn/go-sqlite3.

Notably we depend on a Segment-specific fork that includes a patch which enables preupdate hooks for our code without requiring a build-time flag to be manually put into place by all users of the ctlstore library.

## Details

This depends on https://github.com/segmentio/go-sqlite3/pull/9 to allow the `go get` to succeed.

Once that is merged, we deleted the [segment-v1.14.22](https://github.com/segmentio/go-sqlite3/releases/tag/segment-v1.14.22) tag in that repo and recreated it as [v1.14.22-segment](https://github.com/segmentio/go-sqlite3/releases/tag/v1.14.22-segment).

> [!TIP]
> Despite fixing the `master` of go-sqlite3 to [update module path](https://github.com/segmentio/go-sqlite3/blob/b9c49a6eaf4ca03f2515c9ef9334d20741363b3b/go.mod#L1), I was getting errors doing `go get` after deleting and recreating the `segment-v1.14.22` tag like so:
> ```
> % go get github.com/segmentio/go-sqlite3@segment-v1.14.22
> go: github.com/segmentio/go-sqlite3@segment-v1.14.22 (v1.14.23-0.20240208202956-73b5bef61db6) > requires github.com/segmentio/go-sqlite3@v1.14.23-0.20240208202956-73b5bef61db6: parsing go.mod:
> 	module declares its path as: github.com/mattn/go-sqlite3
> 	        but was required as: github.com/segmentio/go-sqlite3
> ```
>
> @kevinburkesegment explained this was likely due to the Go package cache, so we decided to just delete that previous tag and not try to recreate it. Instead we created a tag with a different name.

Testing completed successfully: 
* [x] ensure CI runs
* [x] verify on other services that include ctlstore client, when those services are updated. https://segment.atlassian.net/browse/IO-1695

> [!NOTE]  
> Replacement for PR #140 which had the wrong version number in its branch name.