### PR TITLE
all: run builds using Go 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
 
-      - name: setup go 1.20
-        uses: actions/setup-go@v3
+      - name: setup go 1.22
+        uses: actions/setup-go@v4
         with:
-            go-version: '1.20'
+            go-version: '1.22'
 
       - name: Deps
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.20-alpine
+FROM golang:1.22-alpine
 ENV SRC github.com/segmentio/ctlstore
 ARG VERSION
 
 RUN apk --update add gcc git curl alpine-sdk libc6-compat ca-certificates sqlite \
-  && curl -SsL https://github.com/segmentio/chamber/releases/download/v2.13.2/chamber-v2.13.2-linux-amd64 -o /bin/chamber \
-  && curl -sL https://github.com/peak/s5cmd/releases/download/v2.1.0/s5cmd_2.1.0_Linux-64bit.tar.gz -o s5cmd.gz && tar -xzf s5cmd.gz -C /bin \
+  && curl -SsL https://github.com/segmentio/chamber/releases/download/v2.14.0/chamber-v2.14.0-linux-amd64 -o /bin/chamber \
+  && curl -sL https://github.com/peak/s5cmd/releases/download/v2.2.2/s5cmd_2.2.2_Linux-64bit.tar.gz -o s5cmd.gz && tar -xzf s5cmd.gz -C /bin \
   && chmod +x /bin/chamber \
   && chmod +x /bin/s5cmd
 
@@ -12,10 +12,10 @@ RUN apk --update add gcc git curl alpine-sdk libc6-compat ca-certificates sqlite
 COPY . /go/src/${SRC}
 WORKDIR /go/src/${SRC}
 RUN go mod vendor
-RUN CGO_ENABLED=1 go install -ldflags="-X github.com/segmentio/ctlstore/pkg/version.version=$VERSION" ${SRC}/pkg/cmd/ctlstore \
+RUN CGO_ENABLED=1 go install -trimpath -ldflags="-X github.com/segmentio/ctlstore/pkg/version.version=$VERSION" ${SRC}/pkg/cmd/ctlstore \
   && cp ${GOPATH}/bin/ctlstore /usr/local/bin
 
-RUN CGO_ENABLED=1 go install -ldflags="-X github.com/segmentio/ctlstore/pkg/version.version=$VERSION" ${SRC}/pkg/cmd/ctlstore-cli \
+RUN CGO_ENABLED=1 go install -trimpath -ldflags="-X github.com/segmentio/ctlstore/pkg/version.version=$VERSION" ${SRC}/pkg/cmd/ctlstore-cli \
   && cp ${GOPATH}/bin/ctlstore-cli /usr/local/bin
 
 FROM alpine

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ clean:
 
 .PHONY: install
 install:
-	$Qgo install ./pkg/cmd/ctlstore
+	$Qgo install -trimpath ./pkg/cmd/ctlstore
 
 .PHONY: build
 build: deps
-	$Qgo build -ldflags="-X github.com/segmentio/ctlstore/pkg/version.version=${VERSION} -X github.com/segmentio/ctlstore/pkg/globalstats.version=${VERSION}" -o ./bin/ctlstore ./pkg/cmd/ctlstore
+	$Qgo build -trimpath -ldflags="-X github.com/segmentio/ctlstore/pkg/version.version=${VERSION} -X github.com/segmentio/ctlstore/pkg/globalstats.version=${VERSION}" -o ./bin/ctlstore ./pkg/cmd/ctlstore
 
 .PHONY: docker
 docker:
@@ -70,9 +70,8 @@ fmtfix:
 
 .PHONY: test
 test:
-	$Qgo test $(GOTESTFLAGS) ./...
+	$Qgo test -trimpath $(GOTESTFLAGS) ./...
 
 .PHONY: bench
 bench:
-	$Qgo test $(GOTESTFLAGS) -bench .
-
+	$Qgo test -trimpath $(GOTESTFLAGS) -bench .


### PR DESCRIPTION
The newest version has better compile and runtime performance.